### PR TITLE
Fix for Issue 14

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -16,14 +16,15 @@ dependencies {
     testCompile group: 'junit', name: 'junit', version: '4.11'
 
     // Dependencies for testing with couchbase-lite-android test suits
-    // testCompile group: 'commons-io', name: 'commons-io', version: '2.0.1'
-    // compile group: 'org.json', name: 'json', version: '20090211'
+    testCompile group: 'commons-io', name: 'commons-io', version: '2.0.1'
+    testCompile 'com.couchbase.lite:java-listener' + version
+    compile group: 'org.json', name: 'json', version: '20090211'
 
     // Dependencies required by couchbase-lite-java-core
     compile group: 'org.apache.httpcomponents', name: 'httpclient', version: '4.0-beta1'
     compile group: 'org.apache.httpcomponents', name: 'httpcore', version: '4.0-beta2'
     compile group: 'commons-logging', name: 'commons-logging', version: '1.1.3'
-    
+
     compile buildAgainstMavenArtifacts == null ?
             project(':libraries:couchbase-lite-java-core') :
             'com.couchbase.lite:java-core:' + version
@@ -65,6 +66,7 @@ uploadArchives {
             repository(url: System.getenv("MAVEN_UPLOAD_REPO_URL")) {
                 authentication(userName: System.getenv("MAVEN_UPLOAD_USERNAME"), password: System.getenv("MAVEN_UPLOAD_PASSWORD"))
             }
+
             pom.version = version
             pom.groupId = 'com.couchbase.lite'
             pom.artifactId = 'java'
@@ -80,3 +82,19 @@ uploadArchives {
         }
     }
 }
+
+task copyAndroidTests(type: Copy) {
+    from "../couchbase-lite-android/src/androidTest/java/com/couchbase/lite"
+    into 'src/test/java/com/couchbase/lite'
+}
+
+task deleteBrokenTests(type: Delete) {
+    delete 'src/test/java/com/couchbase/lite/CollationTest.java', 'src/test/java/com/couchbase/lite/Base64Test.java'
+}
+
+task copyAndroidAssets(type: Copy) {
+    from "../couchbase-lite-android/src/androidTest/assets"
+    into 'src/test/resources/assets'
+}
+
+test.dependsOn(copyAndroidTests, deleteBrokenTests, copyAndroidAssets)

--- a/src/test/java/com/couchbase/test/lite/LiteTestCaseBase.java
+++ b/src/test/java/com/couchbase/test/lite/LiteTestCaseBase.java
@@ -1,0 +1,12 @@
+package com.couchbase.test.lite;
+
+import junit.framework.*;
+
+// https://github.com/couchbase/couchbase-lite-android/issues/285
+
+/**
+ * This class is changed depending on if we are in Android or Java. Amongst other things it lets us
+ * change the base class for tests between TestCase (Java) and AndroidTestCase (Android).
+ */
+public class LiteTestCaseBase extends TestCase {
+}

--- a/src/test/java/com/couchbase/test/lite/LiteTestContextBase.java
+++ b/src/test/java/com/couchbase/test/lite/LiteTestContextBase.java
@@ -1,0 +1,26 @@
+package com.couchbase.test.lite;
+
+// https://github.com/couchbase/couchbase-lite-android/issues/285
+
+import java.io.*;
+import java.nio.file.*;
+
+/**
+ * Provides a platform specific way to create a safe temporary directory location since this is different in Java
+ * and Android
+ */
+public class LiteTestContextBase {
+    private File rootDirectory;
+
+    public LiteTestContextBase() {
+        try {
+            rootDirectory = Files.createTempDirectory("couchbaselitetest").toFile();
+        } catch (IOException e) {
+            throw new RuntimeException("Could not create temp directory!", e);
+        }
+    }
+
+    public File getRootDirectory() {
+        return rootDirectory;
+    }
+}


### PR DESCRIPTION
https://github.com/couchbase/couchbase-lite-java/issues/14
build.gradle - Attaches tasks to test that will copy all the tests from
android to Java, delete tests that are known not to work and copy all
the assets. Note that these are now 'attached' to test so anytime test
is called these tasks will automatically be called first.
   Note that we assume that the android project is in a parallel directory
to the Java project. If that isn't a safe assumption then we can always
just move the location into a property.

LiteTestCaseBase/LiteTestContextBase - Pretty self explanatory.
