### PR TITLE
Make sure we don't check in the wrong things

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,8 @@
 .gradle
 local.properties
 /.DS_Store
+# These should always be copied fresh from Android
+src/test/java/com/couchbase/lite/
+src/test/resources
+# This directory is an artifact created by testing
+couchbaselitetest


### PR DESCRIPTION
Since we shouldn't be dependent on the tests or assets we copy over from Android we should also make sure not to check them in since they will just be overwritten on the next build anyway.

Also the couchbaselitetest directory is an artifact created by testing and shouldn't be checked in either.
