### PR TITLE
Make name consistent

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -10,7 +10,7 @@ repositories {
     mavenCentral()
 }
 
-def buildAgainstMavenArtifacts = System.getProperty("buildAgainstMavenArtifacts")
+def buildAgainstMavenArtifacts = System.getProperty("buildJavaWithArtifacts")
 
 dependencies {
     testCompile group: 'junit', name: 'junit', version: '4.11'


### PR DESCRIPTION
This property is called buildListenerWithArtifacts for listener and buildAndroidWithArtifacts for android so it seems reasonable to name it buildJavaWithArtifacts here. I actually don't understand why there are three different switches. I would think they should all have the same name since it seems weird that someone would build with artifacts in one place and not another.
