### PR TITLE
Final step to make logging actually work

### DIFF
--- a/src/test/java/com/couchbase/test/lite/LiteTestCaseBase.java
+++ b/src/test/java/com/couchbase/test/lite/LiteTestCaseBase.java
@@ -2,6 +2,10 @@ package com.couchbase.test.lite;
 
 import junit.framework.*;
 
+import java.util.logging.Handler;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
 /**
  * This class is changed depending on if we are in Android or Java. Amongst other things it lets us
  * change the base class for tests between TestCase (Java) and AndroidTestCase (Android).
@@ -9,6 +13,17 @@ import junit.framework.*;
  * Reference Issue: https://github.com/couchbase/couchbase-lite-android/issues/285
  */
 public class LiteTestCaseBase extends TestCase {
+
+    @Override
+    protected void setUp() throws Exception {
+        super.setUp();
+        //We have to tell the log handlers to output everything or any logging events below info won't be logged
+        //Taken from http://www.onjava.com/pub/a/onjava/2002/06/19/log.html?page=2
+        Handler[] handlers = Logger.getLogger("").getHandlers();
+        for(Handler handler : handlers) {
+            handler.setLevel(Level.ALL);
+        }
+    }
 
     public void testLiteTestCaseSetupProperly() {
         // Avoid No tests found Assertion Failed Error.


### PR DESCRIPTION
This completes what https://github.com/couchbase/couchbase-lite-java-core/pull/281 started. While https://github.com/couchbase/couchbase-lite-java-core/pull/281 handles getting the logger object to let things below info through it turns out that in the standard Java logging system the handlers have their own separate filters. So even if the logger object is set to accept below info the handler is not. So this code extends the handler to also accept all. With this addition now the logging for the tests actually outputs all logging data.
