### PR TITLE
Added `isNull(int)` for `Cursor` implementation for fixing Java Core 497

### DIFF
--- a/src/main/java/com/couchbase/lite/storage/JavaSQLiteStorageEngine.java
+++ b/src/main/java/com/couchbase/lite/storage/JavaSQLiteStorageEngine.java
@@ -475,6 +475,12 @@ public class JavaSQLiteStorageEngine implements SQLiteStorageEngine {
             _close(handle);
             handle = 0;
         }
+
+        @Override
+        public boolean isNull(int columnIndex) {
+            // TODO: Need to implement JNI interface for this method.
+            return false;
+        }
     }
 
     /**


### PR DESCRIPTION
This is companion PR for https://github.com/couchbase/couchbase-lite-java-core/pull/517

- If user uses latest version of SQLite, this does not require. For older version of SQLite, we need to implement this to avoid crash issue in `View.updateIndex()`