### PR TITLE
Fixed #98 - CBL Java build failure on Jenkins

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -43,6 +43,11 @@ dependencies {
     testCompile group: 'commons-io', name: 'commons-io', version: '2.0.1'
     
     testCompile 'com.squareup.okhttp3:mockwebserver:3.3.1'
+
+    // For JavaScript query test
+    testCompile ('com.couchbase.lite:couchbase-lite-java-javascript:1.4.+'){
+        exclude group: 'com.couchbase.lite', module: 'couchbase-lite-java-core'
+    }
 }
 
 task sourcesJar(type: Jar) {


### PR DESCRIPTION
- `couchbase-lite-java-javascript` was not set as test dependency.