### PR TITLE
New strategy for converting UTF-8 to JString and back.

### DIFF
--- a/src/main/cpp/native_c4document.cc
+++ b/src/main/cpp/native_c4document.cc
@@ -403,8 +403,6 @@ Java_com_couchbase_lite_internal_core_C4Document_put(JNIEnv *env, jclass clazz,
     for (jsize i = 0; i < n; i++) {
         jstring js = (jstring) env->GetObjectArrayElement(jhistory, i);
         jstringSlice *item = new jstringSlice(env, js);
-        if (i >= MaxLocalRefsToUse)
-            item->copyAndReleaseRef();
         historyAlloc.push_back(item); // so its memory won't be freed
         history[i] = *item;
     }
@@ -469,8 +467,6 @@ JNIEXPORT jlong JNICALL Java_com_couchbase_lite_internal_core_C4Document_put2(JN
         for (jsize i = 0; i < n; i++) {
             jstring js = (jstring) env->GetObjectArrayElement(jhistory, i);
             jstringSlice *item = new jstringSlice(env, js);
-            if (i >= MaxLocalRefsToUse)
-                item->copyAndReleaseRef();
             historyAlloc.push_back(item); // so its memory won't be freed
             history[i] = *item;
         }

--- a/src/main/cpp/native_encoder.cc
+++ b/src/main/cpp/native_encoder.cc
@@ -42,8 +42,7 @@ JNIEXPORT jlong JNICALL Java_com_couchbase_lite_internal_fleece_Encoder_init(JNI
  * Signature: (J)J
  */
 JNIEXPORT jlong JNICALL
-Java_com_couchbase_lite_internal_fleece_Encoder_initWithFLEncoder(JNIEnv *env, jclass clazz,
-                                                             jlong jflenc) {
+Java_com_couchbase_lite_internal_fleece_Encoder_initWithFLEncoder(JNIEnv *env, jclass clazz, jlong jflenc) {
     return (jlong) new Encoder((FLEncoder) jflenc);
 }
 
@@ -97,8 +96,7 @@ Java_com_couchbase_lite_internal_fleece_Encoder_writeNull(JNIEnv *env, jclass cl
  * Signature: (JZ)Z
  */
 JNIEXPORT jboolean JNICALL
-Java_com_couchbase_lite_internal_fleece_Encoder_writeBool(JNIEnv *env, jclass clazz, jlong jenc,
-                                                     jboolean jvalue) {
+Java_com_couchbase_lite_internal_fleece_Encoder_writeBool(JNIEnv *env, jclass clazz, jlong jenc, jboolean jvalue) {
     return ((Encoder *) jenc)->writeBool((bool) jvalue);
 }
 
@@ -108,8 +106,7 @@ Java_com_couchbase_lite_internal_fleece_Encoder_writeBool(JNIEnv *env, jclass cl
  * Signature: (JJ)Z
  */
 JNIEXPORT jboolean JNICALL
-Java_com_couchbase_lite_internal_fleece_Encoder_writeInt(JNIEnv *env, jclass clazz, jlong jenc,
-                                                    jlong jvalue) {
+Java_com_couchbase_lite_internal_fleece_Encoder_writeInt(JNIEnv *env, jclass clazz, jlong jenc, jlong jvalue) {
     return ((Encoder *) jenc)->writeInt((int64_t) jvalue);
 }
 
@@ -119,8 +116,7 @@ Java_com_couchbase_lite_internal_fleece_Encoder_writeInt(JNIEnv *env, jclass cla
  * Signature: (JF)Z
  */
 JNIEXPORT jboolean JNICALL
-Java_com_couchbase_lite_internal_fleece_Encoder_writeFloat(JNIEnv *env, jclass clazz, jlong jenc,
-                                                      jfloat jvalue) {
+Java_com_couchbase_lite_internal_fleece_Encoder_writeFloat(JNIEnv *env, jclass clazz, jlong jenc, jfloat jvalue) {
     return ((Encoder *) jenc)->writeFloat((float) jvalue);
 }
 
@@ -130,8 +126,7 @@ Java_com_couchbase_lite_internal_fleece_Encoder_writeFloat(JNIEnv *env, jclass c
  * Signature: (JD)Z
  */
 JNIEXPORT jboolean JNICALL
-Java_com_couchbase_lite_internal_fleece_Encoder_writeDouble(JNIEnv *env, jclass clazz, jlong jenc,
-                                                       jdouble jvalue) {
+Java_com_couchbase_lite_internal_fleece_Encoder_writeDouble(JNIEnv *env, jclass clazz, jlong jenc, jdouble jvalue) {
     return ((Encoder *) jenc)->writeDouble((double) jvalue);
 }
 
@@ -141,8 +136,7 @@ Java_com_couchbase_lite_internal_fleece_Encoder_writeDouble(JNIEnv *env, jclass 
  * Signature: (JLjava/lang/String;)Z
  */
 JNIEXPORT jboolean JNICALL
-Java_com_couchbase_lite_internal_fleece_Encoder_writeString(JNIEnv *env, jclass clazz, jlong jenc,
-                                                       jstring jvalue) {
+Java_com_couchbase_lite_internal_fleece_Encoder_writeString(JNIEnv *env, jclass clazz, jlong jenc, jstring jvalue) {
     jstringSlice value(env, jvalue);
     slice s = value;
     return ((Encoder *) jenc)->writeString(s);
@@ -154,8 +148,7 @@ Java_com_couchbase_lite_internal_fleece_Encoder_writeString(JNIEnv *env, jclass 
  * Signature: (J[B)Z
  */
 JNIEXPORT jboolean JNICALL
-Java_com_couchbase_lite_internal_fleece_Encoder_writeData(JNIEnv *env, jclass clazz, jlong jenc,
-                                                     jbyteArray jvalue) {
+Java_com_couchbase_lite_internal_fleece_Encoder_writeData(JNIEnv *env, jclass clazz, jlong jenc, jbyteArray jvalue) {
     jbyteArraySlice value(env, jvalue, true);
     slice s = value;
     return ((Encoder *) jenc)->writeData(s);
@@ -167,8 +160,7 @@ Java_com_couchbase_lite_internal_fleece_Encoder_writeData(JNIEnv *env, jclass cl
  * Signature: (JJ)Z
  */
 JNIEXPORT jboolean JNICALL
-Java_com_couchbase_lite_internal_fleece_Encoder_writeValue(JNIEnv *env, jclass clazz, jlong jenc,
-                                                      jlong jvalue) {
+Java_com_couchbase_lite_internal_fleece_Encoder_writeValue(JNIEnv *env, jclass clazz, jlong jenc, jlong jvalue) {
     return ((Encoder *) jenc)->writeValue((FLValue) jvalue);
 }
 
@@ -178,8 +170,7 @@ Java_com_couchbase_lite_internal_fleece_Encoder_writeValue(JNIEnv *env, jclass c
  * Signature: (JJ)Z
  */
 JNIEXPORT jboolean JNICALL
-Java_com_couchbase_lite_internal_fleece_Encoder_beginArray(JNIEnv *env, jclass clazz, jlong jenc,
-                                                      jlong jreserve) {
+Java_com_couchbase_lite_internal_fleece_Encoder_beginArray(JNIEnv *env, jclass clazz, jlong jenc, jlong jreserve) {
     return ((Encoder *) jenc)->beginArray((size_t) jreserve);
 }
 
@@ -199,8 +190,7 @@ Java_com_couchbase_lite_internal_fleece_Encoder_endArray(JNIEnv *env, jclass cla
  * Signature: (JJ)Z
  */
 JNIEXPORT jboolean JNICALL
-Java_com_couchbase_lite_internal_fleece_Encoder_beginDict(JNIEnv *env, jclass clazz, jlong jenc,
-                                                     jlong jreserve) {
+Java_com_couchbase_lite_internal_fleece_Encoder_beginDict(JNIEnv *env, jclass clazz, jlong jenc, jlong jreserve) {
     return ((Encoder *) jenc)->beginDict((size_t) jreserve);
 }
 
@@ -210,8 +200,7 @@ Java_com_couchbase_lite_internal_fleece_Encoder_beginDict(JNIEnv *env, jclass cl
  * Signature: (JLjava/lang/String;)Z
  */
 JNIEXPORT jboolean JNICALL
-Java_com_couchbase_lite_internal_fleece_Encoder_writeKey(JNIEnv *env, jclass clazz, jlong jenc,
-                                                    jstring jkey) {
+Java_com_couchbase_lite_internal_fleece_Encoder_writeKey(JNIEnv *env, jclass clazz, jlong jenc, jstring jkey) {
     if (jkey == NULL) return false;
     jstringSlice key(env, jkey);
     slice s = key;

--- a/src/main/cpp/native_fleece.cc
+++ b/src/main/cpp/native_fleece.cc
@@ -229,6 +229,19 @@ Java_com_couchbase_lite_internal_fleece_FLDictIterator_free(JNIEnv *env, jclass 
 
 /*
  * Class:     com_couchbase_lite_internal_fleece_FLValue
+ * Method:    fromJavaString
+ * Signature: (Ljava/lang/String;)J
+ JNIEXPORT jlong JNICALL
+Java_com_couchbase_lite_internal_fleece_FLValue_fromJavaString(JNIEnv *env, jclass clazz, jstring jstr) {
+    jstringSlice str(env, jstr);
+    slice s = str;
+    // I'm pretty sure that this FLValue points to thin air, when this method returns.
+    return (jlong) FLValue_FromData(s, kFLTrusted);
+}
+*/
+
+/*
+ * Class:     com_couchbase_lite_internal_fleece_FLValue
  * Method:    fromData
  * Signature: (J)J
  */

--- a/src/main/cpp/native_fleece.cc
+++ b/src/main/cpp/native_fleece.cc
@@ -244,8 +244,7 @@ Java_com_couchbase_lite_internal_fleece_FLValue_fromData(JNIEnv *env, jclass cla
  * Signature: (J)J
  */
 JNIEXPORT jlong JNICALL
-Java_com_couchbase_lite_internal_fleece_FLValue_fromTrustedData(JNIEnv *env, jclass clazz,
-                                                           jbyteArray jdata) {
+Java_com_couchbase_lite_internal_fleece_FLValue_fromTrustedData(JNIEnv *env, jclass clazz, jbyteArray jdata) {
     jbyteArraySlice data(env, jdata, true);
     slice s = data;
     return (jlong) FLValue_FromData({s.buf, s.size}, kFLTrusted);

--- a/src/main/cpp/native_fleece.cc
+++ b/src/main/cpp/native_fleece.cc
@@ -319,24 +319,7 @@ Java_com_couchbase_lite_internal_fleece_FLValue_asDouble(JNIEnv *env, jclass cla
 JNIEXPORT jstring JNICALL
 Java_com_couchbase_lite_internal_fleece_FLValue_asString(JNIEnv *env, jclass clazz, jlong jvalue) {
     FLString str = FLValue_AsString((FLValue) jvalue);
-    const char* newBytes;
-    ssize_t len = UTF8ToModifiedUTF8((const char*)str.buf, &newBytes, str.size);
-    if(len == -1) {
-        jclass c = env->FindClass("java/lang/OutOfMemoryError");
-        env->ThrowNew(c, "Out of memory in FLValue_AsString");
-        return nullptr;
-    }
-
-    C4Slice endStr {str.buf, str.size};
-    if(newBytes != nullptr) {
-        endStr.buf = newBytes;
-        endStr.size = len;
-    }
-
-    jstring retVal = toJString(env, endStr);
-    free((void *)newBytes);
-
-    return retVal;
+    return toJString(env, str);
 }
 
 /*

--- a/src/main/cpp/native_fleece.cc
+++ b/src/main/cpp/native_fleece.cc
@@ -229,19 +229,6 @@ Java_com_couchbase_lite_internal_fleece_FLDictIterator_free(JNIEnv *env, jclass 
 
 /*
  * Class:     com_couchbase_lite_internal_fleece_FLValue
- * Method:    fromJavaString
- * Signature: (Ljava/lang/String;)J
- JNIEXPORT jlong JNICALL
-Java_com_couchbase_lite_internal_fleece_FLValue_fromJavaString(JNIEnv *env, jclass clazz, jstring jstr) {
-    jstringSlice str(env, jstr);
-    slice s = str;
-    // I'm pretty sure that this FLValue points to thin air, when this method returns.
-    return (jlong) FLValue_FromData(s, kFLTrusted);
-}
-*/
-
-/*
- * Class:     com_couchbase_lite_internal_fleece_FLValue
  * Method:    fromData
  * Signature: (J)J
  */

--- a/src/main/cpp/native_glue.cc
+++ b/src/main/cpp/native_glue.cc
@@ -88,12 +88,8 @@ std::string litecore::jni::JstringToUTF8(JNIEnv *env, jstring jstr) {
                 .to_bytes(reinterpret_cast<const char16_t *>(chars), reinterpret_cast<const char16_t *>(chars + len));
     }
     catch (const std::exception &x) {
-        env->ReleaseStringChars(jstr, chars);
-
-        C4Error error = {LiteCoreDomain, kC4ErrorMemoryError, 0};
-        throwError(env, error);
-
-        return std::string();
+        // ??? Callers can't handle exceptions, so we just ignore errors and return an empty string.
+        str = std::string();
     }
 
     env->ReleaseStringChars(jstr, chars);

--- a/src/main/cpp/native_glue.cc
+++ b/src/main/cpp/native_glue.cc
@@ -19,140 +19,74 @@
 #include "native_glue.hh"
 #include <queue>
 #include <new>
+#include <codecvt>
+#include <locale>
 
 using namespace litecore;
 using namespace litecore::jni;
 using namespace std;
 
-namespace litecore { namespace jni {
-        void UTF8CharToModifiedUTF8(const char *input, char *output);
-        void ModifiedUTF8ToUTF8(char* input);
-        void ModifiedUTF8CharToUTF8(char* input);
+namespace litecore {
+    namespace jni {
+        std::string JstringToUTF8(JNIEnv *env, jstring jstr);
+
+        jstring UTF8ToJstring(JNIEnv *env, std::string str);
     }
 }
 
-void litecore::jni::UTF8CharToModifiedUTF8(const char *input, char *output) {
-    char c = input[0];
-    char c1 = input[1] & 0x3F;
-    char c2 = input[2] & 0x3F;
-    char c3 = input[3] & 0x3F;
+// Java uses Modified-UTF-8, not UTF-8: Attempting to decode a real UTF-8 string will cause a failure that looks like:
+//   art/runtime/check_jni.cc:65] JNI DETECTED ERROR IN APPLICATION: input is not valid Modified UTF-8: illegal start byte ...
+//   art/runtime/check_jni.cc:65]     string: ...
+//   art/runtime/check_jni.cc:65]     in call to NewStringUTF
+// See:
+//   https://stackoverflow.com/questions/35519823/jni-detected-error-in-application-input-is-not-valid-modified-utf-8-illegal-st
+// The strategy here is to use standard C functions to convert the UTF-8 directly to UTF-16, which Java handles nicely.
+// The following two functions are taken from this repo:
+//   https://github.com/incanus/android-jni/blob/master/app/src/main/jni/JNI.cpp#L57-L86
 
-    int unicodePoint = ((c & 0x07) << 18) | (c1 << 12) | (c2 << 6) | c3;
-    unicodePoint -= 0x10000;
+jstring litecore::jni::UTF8ToJstring(JNIEnv *env, std::string str) { // < !!! SHOULD BE REF?
+    std::u16string ustr = std::wstring_convert<std::codecvt_utf8_utf16<char16_t>, char16_t>().from_bytes(str);
 
-    int surrogates[2] { 0xD800 | (unicodePoint >> 10), 0xDC00 | (unicodePoint & 0x3FF) };
+    jstring jstr = env->NewString(reinterpret_cast<const jchar *>(ustr.c_str()), ustr.size());
+    if (jstr == nullptr) {
+        env->ExceptionDescribe();
+        return nullptr;
+    }
 
-    output[0] = (surrogates[0]>>12 & 0x0F) | 0xE0;
-    output[1] = (surrogates[0]>>6  & 0x3F) | 0x80;
-    output[2] = (surrogates[0]     & 0x3F) | 0x80;
-    output[3] = (surrogates[1]>>12 & 0x0F) | 0xE0;
-    output[4] = (surrogates[1]>>6  & 0x3F) | 0x80;
-    output[5] = (surrogates[1]     & 0x3F) | 0x80;
+    return jstr;
 }
 
-ssize_t litecore::jni::UTF8ToModifiedUTF8(const char* input, const char** output, size_t len){
-    // https://github.com/android-ndk/ndk/issues/283
-    size_t extraBytes = 0;
-    const auto unsignedInput = (const uint8_t *)input;
+std::string litecore::jni::JstringToUTF8(JNIEnv *env, jstring jstr) {
+    std::string str;
 
-    // Need to figure out the actual length since each
-    // 4-bytes of real UTF-8 is 6 bytes of modified UTF-8
-    // but convert the bytes while we are at it
-    for(size_t i = 0; i < len; i++) {
-        if(unsignedInput[i] >= 0xF0) {
-            // 0xF0 and above marks 4-byte sequences
-            extraBytes += 2;
-
-            // 3 + 1 from next loop iteration = 4 bytes advance
-            i += 3;
-        }
+    jsize len = env->GetStringLength(jstr);
+    if (len < 0) {
+        env->ExceptionDescribe();
+        return str;
     }
 
-    if(extraBytes == 0) {
-        // No modifications necessary
-        *output = nullptr;
-        return len;
+    const jchar *chars = env->GetStringChars(jstr, nullptr);
+    if (chars == nullptr) {
+        env->ExceptionDescribe();
+        return str;
     }
 
-    size_t newStrLen = len + extraBytes;
-    char* newBytes = (char *)malloc(newStrLen);
-    if(newBytes == nullptr) {
-        *output = nullptr;
-        return -1;
-    }
+    std::u16string ustr(reinterpret_cast<const char16_t *>(chars), len);
 
-    int offset = 0;
-    for(size_t i = 0; i < len; i++) {
-        if(unsignedInput[i] >= 0xF0) {
-            UTF8CharToModifiedUTF8(input + i, newBytes + i + offset);
-            i += 3;
-            offset += 2;
-        } else {
-            newBytes[i+offset] = unsignedInput[i];
-        }
-    }
+    env->ReleaseStringChars(jstr, chars);
+    chars = nullptr;
 
-    *output = newBytes;
-    return newStrLen;
-}
-
-void litecore::jni::ModifiedUTF8CharToUTF8(char *input) {
-    char c = input[0];
-    char c1 = input[1] & 0x3F;
-    char c2 = input[2] & 0x3F;
-    char d = input[3];
-    char d1 = input[4] & 0x3F;
-    char d2 = input[5] & 0x3F;
-
-    int surrogate[2] = { ((c & 0x0F) << 12) | (c1 << 6) | c2, ((d & 0x0F) << 12) | (d1 << 6) | d2 };
-    int codePoint = ((surrogate[0] - 0xD800) << 10) + (surrogate[1] - 0xDC00) + 0x10000;
-
-    input[0] = 0xF0 | (codePoint  >> 18);
-    input[1] = 0x80 | ((codePoint >> 12) & 0x3F);
-    input[2] = 0x80 | ((codePoint >> 6) & 0x3F);
-    input[3] = 0x80 | ((codePoint & 0x3F));
-}
-
-void litecore::jni::ModifiedUTF8ToUTF8(char *input) {
-    size_t len = 0;
-    size_t i = 0;
-    bool needsModify = false;
-    for(i = 0; input[i] != 0; i++) {
-        if(input[i] == '\xed') {
-            // According to https://docs.oracle.com/javase/1.5.0/docs/guide/jni/spec/types.html#wp16542
-            // modified UTF-8 for codepoints > FFFF will always start with 0xED
-            needsModify = true;
-            ModifiedUTF8CharToUTF8(&input[i]);
-            i += 5;
-        }
-    }
-
-    if(!needsModify) {
-        return;
-    }
-
-    len = i;
-    size_t j = 0;
-    for(i = 0; input[i] != 0; i++) {
-        if((uint8_t)input[i] >= 0xF0) {
-            i+= 3;
-            size_t j;
-            for(j = i + 1; j < len - 2; j++) {
-                input[j] = input[j+2];
-            }
-
-            input[j] = 0;
-        }
-    }
+    str = std::wstring_convert<std::codecvt_utf8_utf16<char16_t>, char16_t>().to_bytes(ustr);
+    return str;
 }
 
 /*
  * Will be called by JNI when the library is loaded
  *
  * NOTE:
- *  All resources allocated here are never released by application
- *  we rely on system to free all global refs when it goes away,
- *  the pairing function JNI_OnUnload() never get called at all.
+ *  Resources allocated here are never explicitly released.
+ *  We rely on system to free all global refs when it goes away,
+ *  the pairing function JNI_OnUnload() will never get called at all.
  */
 JNIEXPORT jint JNICALL
 JNI_OnLoad(JavaVM *jvm, void *reserved) {
@@ -188,41 +122,34 @@ namespace litecore {
             }
         }
 
-        jstringSlice::jstringSlice(JNIEnv *env, jstring js)
-                : _env(nullptr) {
+        jstringSlice::jstringSlice(JNIEnv *env, jstring js) {
             assert(env != nullptr);
             if (js != nullptr) {
-                jboolean isCopy;
-                _jstr = js;
-                _env = env;
 
-                char *cstr = (char *)env->GetStringUTFChars(js, &isCopy);
-                assert(isCopy);
-                ModifiedUTF8ToUTF8(cstr);
-                if (!cstr)
-                    return; // Would it be better to throw an exception?
+                // !!! COPYING THE STRING 2x?
+                auto str = JstringToUTF8(env, js);
+
+                auto buf = (char *) malloc(str.length() + 1);
+                if (buf == nullptr) {
+                    jclass c = env->FindClass("java/lang/OutOfMemoryError");
+                    env->ThrowNew(c, "Out of memory creating String slice");
+                }
+                char *cstr = strcpy(buf, str.c_str());;
+
                 _slice = slice(cstr);
             }
         }
 
         jstringSlice::~jstringSlice() {
-            if (_env)
-                _env->ReleaseStringUTFChars(_jstr, (const char *) _slice.buf);
-            else if (_slice.buf)
-                free((void *) _slice.buf);        // detached
+            free((void *) _slice.buf);
         }
 
+        // !!! DOES THIS STILL WORK?  IS IT STILL NECESSARY?
         void jstringSlice::copyAndReleaseRef() {
-            if (_env) {
-                auto cstr = (const char *) _slice.buf;
-                _slice = _slice.copy();
-                _env->ReleaseStringUTFChars(_jstr, cstr);
-                _env->DeleteLocalRef(_jstr);
-                _env = nullptr;
-            }
+            _slice = _slice.copy();
         }
 
-        const char* jstringSlice::cStr() {
+        const char *jstringSlice::cStr() {
             return static_cast<const char *>(_slice.buf);
         };
 
@@ -280,9 +207,10 @@ namespace litecore {
         jstring toJString(JNIEnv *env, C4Slice s) {
             if (s.buf == nullptr)
                 return nullptr;
+
             std::string utf8Buf((char *) s.buf, s.size);
-            // NOTE: This return value will be taken care by JVM. So not necessary to free by our self
-            return env->NewStringUTF(utf8Buf.c_str());
+
+            return UTF8ToJstring(env, utf8Buf);
         }
 
         jstring toJString(JNIEnv *env, C4SliceResult s) {

--- a/src/main/cpp/native_glue.cc
+++ b/src/main/cpp/native_glue.cc
@@ -128,11 +128,6 @@ namespace litecore {
             }
         }
 
-        // !!! DOES THIS STILL WORK?  IS IT STILL NECESSARY?
-        void jstringSlice::copyAndReleaseRef() {
-            _slice = _slice.copy();
-        }
-
         const char *jstringSlice::cStr() {
             return static_cast<const char *>(_slice.buf);
         };

--- a/src/main/cpp/native_glue.hh
+++ b/src/main/cpp/native_glue.hh
@@ -46,8 +46,6 @@ namespace litecore {
         bool initC4Replicator(JNIEnv *); // Implemented in native_c4replicator.cc
         bool initC4Socket(JNIEnv *);     // Implemented in native_c4socket.cc
 
-        ssize_t UTF8ToModifiedUTF8(const char* input, const char** output, size_t len);
-
         // Creates a temporary slice value from a Java String object
         class jstringSlice {
         public:
@@ -56,8 +54,7 @@ namespace litecore {
             ~jstringSlice();
 
             jstringSlice(jstringSlice &&s) // move constructor
-                    : _slice(s._slice), _env(s._env), _jstr(s._jstr) {
-                s._env = nullptr;
+                    : _slice(s._slice) {
                 s._slice = nullslice;
             }
 
@@ -71,11 +68,7 @@ namespace litecore {
             const char* cStr();
 
         private:
-            static void UTF8ToModifiedUTF8(const char* input, char* output);
-
             slice _slice;
-            JNIEnv *_env;
-            jstring _jstr;
         };
 
 

--- a/src/main/cpp/native_glue.hh
+++ b/src/main/cpp/native_glue.hh
@@ -51,10 +51,9 @@ namespace litecore {
         public:
             jstringSlice(JNIEnv *env, jstring js);
 
-            ~jstringSlice();
-
             jstringSlice(jstringSlice &&s) // move constructor
-                    : _slice(s._slice) {
+                    : _str(s._str), _slice(s._slice) {
+                s._str = nullptr;
                 s._slice = nullslice;
             }
 
@@ -68,6 +67,7 @@ namespace litecore {
             const char* cStr();
 
         private:
+            std::string _str;
             slice _slice;
         };
 

--- a/src/main/cpp/native_glue.hh
+++ b/src/main/cpp/native_glue.hh
@@ -52,10 +52,7 @@ namespace litecore {
             jstringSlice(JNIEnv *env, jstring js);
 
             jstringSlice(jstringSlice &&s) // move constructor
-                    : _str(s._str), _slice(s._slice) {
-                s._str = nullptr;
-                s._slice = nullslice;
-            }
+                    : _str(std::move(s._str)), _slice(s._slice) {}
 
             operator slice() { return _slice; }
 

--- a/src/main/cpp/native_glue.hh
+++ b/src/main/cpp/native_glue.hh
@@ -61,9 +61,6 @@ namespace litecore {
 
             operator C4Slice() { return {_slice.buf, _slice.size}; }
 
-            // Copies the string data and releases the JNI local ref.
-            void copyAndReleaseRef();
-
             const char* cStr();
 
         private:

--- a/src/main/java/com/couchbase/lite/LiveQuery.java
+++ b/src/main/java/com/couchbase/lite/LiveQuery.java
@@ -17,7 +17,9 @@
 //
 package com.couchbase.lite;
 
+import android.support.annotation.MainThread;
 import android.support.annotation.NonNull;
+import android.support.annotation.WorkerThread;
 
 import java.util.Locale;
 import java.util.concurrent.Executor;
@@ -51,6 +53,7 @@ final class LiveQuery implements DatabaseChangeListener {
     // Constructors
     //---------------------------------------------
 
+    @MainThread
     LiveQuery(AbstractQuery query) {
         if (query == null) { throw new IllegalArgumentException("query should not be null."); }
 
@@ -76,6 +79,7 @@ final class LiveQuery implements DatabaseChangeListener {
     // Implementation of DatabaseChangeListener
     //---------------------------------------------
 
+    @MainThread
     @Override
     public void changed(@NonNull DatabaseChange change) {
         synchronized (lock) {
@@ -110,6 +114,7 @@ final class LiveQuery implements DatabaseChangeListener {
     /**
      * Starts observing database changes and reports changes in the query result.
      */
+    @MainThread
     void start() {
         synchronized (lock) {
             if (query.getDatabase() == null) {
@@ -156,6 +161,7 @@ final class LiveQuery implements DatabaseChangeListener {
     /**
      * Stops observing database changes.
      */
+    @MainThread
     private void stop(boolean removeFromList) {
         synchronized (lock) {
             observing = false;
@@ -176,6 +182,7 @@ final class LiveQuery implements DatabaseChangeListener {
      *
      * @param delay millisecond
      */
+    @MainThread
     private void update(long delay) {
         if (willUpdate) {
             return; // Already a pending update scheduled
@@ -197,6 +204,7 @@ final class LiveQuery implements DatabaseChangeListener {
      * NOTE: update() method is called from only ExecutorService for LiveQuery which is
      * a single thread. But update changes and refers some instant variables
      */
+    @WorkerThread
     private void update() {
         synchronized (lock) {
             if (!observing) { return; }

--- a/src/main/java/com/couchbase/lite/internal/fleece/AllocSlice.java
+++ b/src/main/java/com/couchbase/lite/internal/fleece/AllocSlice.java
@@ -19,20 +19,13 @@ package com.couchbase.lite.internal.fleece;
 
 
 public class AllocSlice {
-    static native long init(byte[] bytes);
-
-    static native void free(long slice);
-
-    static native byte[] getBuf(long slice);
-
-    static native long getSize(long slice);
-
-    private boolean shouldRetain;  // true -> not release native object, false -> release by free()
-    long handle;         // hold pointer to alloc_slice*
+    private boolean shouldRetain; // true -> not release native object, false -> release by free()
+    long handle; // hold pointer to alloc_slice*
 
     //-------------------------------------------------------------------------
-    // public methods
+    // constructors
     //-------------------------------------------------------------------------
+
     public AllocSlice(byte[] bytes) {
         this(init(bytes), false);
     }
@@ -43,13 +36,13 @@ public class AllocSlice {
         this.shouldRetain = retain;
     }
 
+    //-------------------------------------------------------------------------
+    // public methods
+    //-------------------------------------------------------------------------
+
     public long getHandle() {
         return handle;
     }
-
-    //-------------------------------------------------------------------------
-    // native methods
-    //-------------------------------------------------------------------------
 
     public byte[] getBuf() {
         return getBuf(handle);
@@ -67,6 +60,7 @@ public class AllocSlice {
     //-------------------------------------------------------------------------
     // protected methods
     //-------------------------------------------------------------------------
+
     @SuppressWarnings("NoFinalizer")
     @Override
     protected void finalize() throws Throwable {
@@ -74,10 +68,26 @@ public class AllocSlice {
         super.finalize();
     }
 
+    //-------------------------------------------------------------------------
+    // private methods
+    //-------------------------------------------------------------------------
+
     private void free() {
         if (handle != 0L && !shouldRetain) {
             free(handle);
             handle = 0L;
         }
     }
+
+    //-------------------------------------------------------------------------
+    // native methods
+    //-------------------------------------------------------------------------
+
+    static native long init(byte[] bytes);
+
+    static native void free(long slice);
+
+    static native byte[] getBuf(long slice);
+
+    static native long getSize(long slice);
 }

--- a/src/main/java/com/couchbase/lite/internal/fleece/Encoder.java
+++ b/src/main/java/com/couchbase/lite/internal/fleece/Encoder.java
@@ -25,56 +25,18 @@ import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 
 
 public class Encoder {
-    static native long init();
-
-    static native long initWithFLEncoder(long enc);
-
-    static native void free(long handle);
-
-    static native void release(long handle);
-
-    static native long getFLEncoder(long handle);
-
-    static native boolean writeNull(long handle);
-
-    static native boolean writeBool(long handle, boolean value);
-
-    static native boolean writeInt(long handle, long value); // 64bit
-
-    static native boolean writeFloat(long handle, float value);
-
-    static native boolean writeDouble(long handle, double value);
-
-    static native boolean writeString(long handle, String value);
-
-    static native boolean writeData(long handle, byte[] value);
-
-    static native boolean writeValue(long handle, long value);
-
-    static native boolean beginArray(long handle, long reserve);
-
-    static native boolean endArray(long handle);
-
-    static native boolean beginDict(long handle, long reserve);
-
-    static native boolean writeKey(long handle, String slice);
-
-    static native boolean endDict(long handle);
-
-    static native long finish(long handle);
-
     private long handle; // hold pointer to Encoder*
     private FLEncoder flEncoder;
 
     private final boolean managed;
 
+    //-------------------------------------------------------------------------
+    // constructors
+    //-------------------------------------------------------------------------
+
     public Encoder() {
         this(init(), false);
     }
-
-    //-------------------------------------------------------------------------
-    // native methods
-    //-------------------------------------------------------------------------
 
     public Encoder(FLEncoder enc) {
         this(initWithFLEncoder(enc.handle), false);
@@ -86,6 +48,10 @@ public class Encoder {
         this.handle = handle;
         this.managed = managed;
     }
+
+    //-------------------------------------------------------------------------
+    // public methods
+    //-------------------------------------------------------------------------
 
     public void release() {
         if (handle != 0L && !managed) {
@@ -154,6 +120,7 @@ public class Encoder {
                 writeObject(item);
             }
         }
+
         return endArray();
     }
 
@@ -212,12 +179,17 @@ public class Encoder {
     //-------------------------------------------------------------------------
     // protected methods
     //-------------------------------------------------------------------------
+
     @SuppressWarnings("NoFinalizer")
     @Override
     protected void finalize() throws Throwable {
         free();
         super.finalize();
     }
+
+    //-------------------------------------------------------------------------
+    // private methods
+    //-------------------------------------------------------------------------
 
     private void free() {
         if (handle != 0L && !managed) {
@@ -230,4 +202,46 @@ public class Encoder {
         if (flEncoder == null) { flEncoder = new FLEncoder(getFLEncoder(handle), true); }
         return flEncoder;
     }
+
+    //-------------------------------------------------------------------------
+    // native methods
+    //-------------------------------------------------------------------------
+
+    static native long init();
+
+    static native long initWithFLEncoder(long enc);
+
+    static native void free(long handle);
+
+    static native void release(long handle);
+
+    static native long getFLEncoder(long handle);
+
+    static native boolean writeNull(long handle);
+
+    static native boolean writeBool(long handle, boolean value);
+
+    static native boolean writeInt(long handle, long value); // 64bit
+
+    static native boolean writeFloat(long handle, float value);
+
+    static native boolean writeDouble(long handle, double value);
+
+    static native boolean writeString(long handle, String value);
+
+    static native boolean writeData(long handle, byte[] value);
+
+    static native boolean writeValue(long handle, long value);
+
+    static native boolean beginArray(long handle, long reserve);
+
+    static native boolean endArray(long handle);
+
+    static native boolean beginDict(long handle, long reserve);
+
+    static native boolean writeKey(long handle, String slice);
+
+    static native boolean endDict(long handle);
+
+    static native long finish(long handle);
 }

--- a/src/main/java/com/couchbase/lite/internal/fleece/FLValue.java
+++ b/src/main/java/com/couchbase/lite/internal/fleece/FLValue.java
@@ -36,6 +36,10 @@ public class FLValue {
     public static FLValue fromData(byte[] data) {
         return new FLValue(fromTrustedData(data));
     }
+//
+//    public static FLValue fromString(String str) {
+//        return new FLValue(fromJavaString(str));
+//    }
 
     public static Object toObject(FLValue flValue) {
         return flValue.asObject();
@@ -117,23 +121,20 @@ public class FLValue {
         return asDouble(handle);
     }
 
-    public String asString() { return asString(handle); }
-
-    public FLDict asFLDict() {
-        return new FLDict(asDict(handle));
+    // ??? If we are out of memory or the string cannot be decoded, we just lose it
+    public String asString() {
+        try { return asString(handle); }
+        catch (LiteCoreException ignore) {}
+        return null;
     }
 
-    public FLArray asFLArray() {
-        return new FLArray(asArray(handle));
-    }
+    public FLDict asFLDict() { return new FLDict(asDict(handle)); }
 
-    public Map<String, Object> asDict() {
-        return asFLDict().asDict();
-    }
+    public FLArray asFLArray() { return new FLArray(asArray(handle)); }
 
-    public List<Object> asArray() {
-        return asFLArray().asArray();
-    }
+    public Map<String, Object> asDict() { return asFLDict().asDict(); }
+
+    public List<Object> asArray() { return asFLArray().asArray(); }
 
     public Object asObject() {
         switch (getType(handle)) {
@@ -175,6 +176,7 @@ public class FLValue {
     //-------------------------------------------------------------------------
     // native methods
     //-------------------------------------------------------------------------
+
     /**
      * Returns a pointer to the root value in the encoded data
      *
@@ -263,7 +265,7 @@ public class FLValue {
      * @param value FLValue
      * @return String
      */
-    static native String asString(long value);
+    static native String asString(long value) throws LiteCoreException;
 
     /**
      * Returns the exact contents of a data value, or null for all other types.
@@ -298,6 +300,8 @@ public class FLValue {
      */
     @SuppressWarnings({"MethodName", "PMD.MethodNamingConventions"})
     static native String JSON5ToJSON(String json5) throws LiteCoreException;
+//
+//    static native long fromJavaString(String str);
 
     static native long fromData(long slice);
 

--- a/src/main/java/com/couchbase/lite/internal/fleece/FLValue.java
+++ b/src/main/java/com/couchbase/lite/internal/fleece/FLValue.java
@@ -45,7 +45,6 @@ public class FLValue {
         return JSON5ToJSON(json5);
     }
 
-
     //-------------------------------------------------------------------------
     // Member Variables
     //-------------------------------------------------------------------------
@@ -118,9 +117,7 @@ public class FLValue {
         return asDouble(handle);
     }
 
-    public String asString() {
-        return asString(handle);
-    }
+    public String asString() { return asString(handle); }
 
     public FLDict asFLDict() {
         return new FLDict(asDict(handle));

--- a/src/main/java/com/couchbase/lite/internal/fleece/FLValue.java
+++ b/src/main/java/com/couchbase/lite/internal/fleece/FLValue.java
@@ -36,10 +36,6 @@ public class FLValue {
     public static FLValue fromData(byte[] data) {
         return new FLValue(fromTrustedData(data));
     }
-//
-//    public static FLValue fromString(String str) {
-//        return new FLValue(fromJavaString(str));
-//    }
 
     public static Object toObject(FLValue flValue) {
         return flValue.asObject();
@@ -300,8 +296,6 @@ public class FLValue {
      */
     @SuppressWarnings({"MethodName", "PMD.MethodNamingConventions"})
     static native String JSON5ToJSON(String json5) throws LiteCoreException;
-//
-//    static native long fromJavaString(String str);
 
     static native long fromData(long slice);
 


### PR DESCRIPTION
This should fix https://issues.couchbase.com/browse/CBSE-6741

The new strategy for UTF-8/JString conversion is just to avoid Modified UTF-8 all together.  Use C++ conversion functions to convert UTF-8 <> UTF-16 and leave the rest to Java