### PR TITLE
Make Document.getRevisionID() public API (CBL-150)

### DIFF
--- a/src/main/java/com/couchbase/lite/AbstractDatabase.java
+++ b/src/main/java/com/couchbase/lite/AbstractDatabase.java
@@ -1213,8 +1213,8 @@ abstract class AbstractDatabase {
             DOMAIN,
             "Resolving doc '%s' (local=%s and remote=%s) with resolver %s",
             docID,
-            localDoc.getRevID(),
-            remoteDoc.getRevID(),
+            localDoc.getRevisionID(),
+            remoteDoc.getRevisionID(),
             resolver);
 
         final Document doc;
@@ -1282,7 +1282,7 @@ abstract class AbstractDatabase {
             // Ask LiteCore to do the resolution:
             final C4Document rawDoc = localDoc.getC4doc();
             // The remote branch has to win so that the doc revision history matches the server's.
-            rawDoc.resolveConflict(remoteDoc.getRevID(), localDoc.getRevID(), mergedBodyBytes, mergedFlags);
+            rawDoc.resolveConflict(remoteDoc.getRevisionID(), localDoc.getRevisionID(), mergedBodyBytes, mergedFlags);
             rawDoc.save(0);
 
             Log.i(DOMAIN, "Conflict resolved as doc '%s' rev %s", rawDoc.getDocID(), rawDoc.getRevID());

--- a/src/main/java/com/couchbase/lite/ConflictResolver.java
+++ b/src/main/java/com/couchbase/lite/ConflictResolver.java
@@ -53,7 +53,7 @@ class DefaultConflictResolver implements ConflictResolver {
         else if (localGen < remoteGen) { return remoteDoc; }
 
         // otherwise, choose one randomly, but deterministically.
-        final String localRevId = localDoc.getRevID();
-        return ((localRevId != null) && (localRevId.compareTo(remoteDoc.getRevID()) > 0)) ? localDoc : remoteDoc;
+        final String localRevId = localDoc.getRevisionID();
+        return ((localRevId != null) && (localRevId.compareTo(remoteDoc.getRevisionID()) > 0)) ? localDoc : remoteDoc;
     }
 }

--- a/src/main/java/com/couchbase/lite/Document.java
+++ b/src/main/java/com/couchbase/lite/Document.java
@@ -123,6 +123,18 @@ public class Document implements DictionaryInterface, Iterable<String> {
     public String getId() { return id; }
 
     /**
+     * Get the document's revision id. The revision id in the Document class is a constant, while
+     * the revision id in the MutableDocument class is not. The newly created Document will have
+     * a null revision id. The revision id in MutableDocument will be updated on save.
+     * The revision id format is opaque, which means its format has no meaning and shouldn't be
+     * parsed to get information.
+     *
+     * @return the document's revision id
+     */
+    public String getRevisionID() {
+        synchronized (lock) { return c4doc == null ? null : c4doc.getSelectedRevID(); }
+    }
+    /**
      * Return the sequence number of the document in the database.
      * This indicates how recently the document has been changed: every time any document is updated,
      * the database assigns it the next sequential sequence number. Thus, if a document's `sequence`
@@ -375,7 +387,7 @@ public class Document implements DictionaryInterface, Iterable<String> {
 
     boolean isEmpty() { return internalDict.isEmpty(); }
 
-    boolean isNewDocument() { return getRevID() == null; }
+    boolean isNewDocument() { return getRevisionID() == null; }
 
     /**
      * Return whether the document exists in the database.
@@ -395,11 +407,7 @@ public class Document implements DictionaryInterface, Iterable<String> {
 
     // TODO: c4rev_getGeneration
     long generation() {
-        synchronized (lock) { return generationFromRevID(getRevID()); }
-    }
-
-    String getRevID() {
-        synchronized (lock) { return c4doc == null ? null : c4doc.getSelectedRevID(); }
+        synchronized (lock) { return generationFromRevID(getRevisionID()); }
     }
 
     void setId(String id) { this.id = id; }


### PR DESCRIPTION
* Renamed Document.getRevID() to getRevisionID() and made it public.
* Refactored the code due to method name change accordingly.