### PR TITLE
Implement NativeLibraryLoader and CouchbaseLite for Java (CBL-161)

### DIFF
--- a/src/ce/java/com/couchbase/lite/CouchbaseLite.java
+++ b/src/ce/java/com/couchbase/lite/CouchbaseLite.java
@@ -18,9 +18,16 @@ package com.couchbase.lite;
 import android.support.annotation.NonNull;
 
 import com.couchbase.lite.internal.ExecutionService;
+import com.couchbase.lite.internal.fleece.MValue;
+
+import java.io.File;
+import java.nio.file.Paths;
 
 public final class CouchbaseLite {
-    private CouchbaseLite() {}
+    private CouchbaseLite() {
+        NativeLibraryLoader.load();
+        MValue.registerDelegate(new MValueDelegate());
+    }
 
     public static void init() { }
 
@@ -28,15 +35,21 @@ public final class CouchbaseLite {
         return null;
     }
 
-    public static String getDbDirectoryPath() {
-        return null;
+    static String getDbDirectoryPath() {
+        return Paths.get("").toAbsolutePath().toString();
     }
 
-    public static String getTmpDirectory(@NonNull String name) {
-        return null;
+    static String getTmpDirectory(@NonNull String name) {
+        String root = new File(System.getProperty("java.io.tmpdir")).getAbsolutePath();
+        return getTmpDirectory(root, name);
     }
 
-    public static String getTmpDirectory(String root, String name) {
-        return null;
+    static String getTmpDirectory(String root, String name) {
+        final File dir = new File(root, name);
+
+        final String path = dir.getAbsolutePath();
+        if ((dir.exists() || dir.mkdirs()) && dir.isDirectory()) { return path; }
+
+        throw new IllegalStateException("Cannot create or access temp directory at " + path);
     }
 }

--- a/src/ce/java/com/couchbase/lite/NativeLibraryLoader.java
+++ b/src/ce/java/com/couchbase/lite/NativeLibraryLoader.java
@@ -1,0 +1,116 @@
+//
+// NativeLibraryLoader.java
+//
+// Copyright (c) 2019 Couchbase, Inc All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+package com.couchbase.lite;
+
+import android.support.annotation.NonNull;
+
+import java.io.File;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+final class NativeLibraryLoader {
+    private static final String[] LIBRARIES = { "LiteCore", "LiteCoreJNI" };
+
+    private static final String LIBS_RES_PATH = "/libs";
+
+    private static final String TMP_DIR_NAME = "com.couchbase.lite.java";
+
+    private static final AtomicBoolean LOADED = new AtomicBoolean(false);
+
+    static void load() {
+        if (LOADED.getAndSet(true)) { return; }
+
+        for (String lib : LIBRARIES) { load(lib); }
+    }
+
+    private static void load(String libName) {
+        try {
+            File libFile = extractLibrary(libName);
+            System.load(libFile.getAbsolutePath());
+        }
+        catch (Exception e) {
+            throw new IllegalStateException("Cannot extract and load library: " + libName, e);
+        }
+    }
+
+    @NonNull
+    private static File extractLibrary(@NonNull String libName) throws IOException, InterruptedException {
+        String libResPath = getLibraryResourcePath(libName);
+        String tmpDir = CouchbaseLite.getTmpDirectory(TMP_DIR_NAME);
+        String targetDir = new File(tmpDir).getAbsolutePath();
+        File targetFile = new File(targetDir, System.mapLibraryName(libName));
+
+        if (targetFile.exists()) {
+            if (!targetFile.delete()) {
+                throw new IllegalStateException("Failed to delete the existing native library at " +
+                        targetFile.getAbsolutePath());
+            }
+        }
+
+        // Extract the library to the target directory:
+        InputStream in = NativeLibraryLoader.class.getResourceAsStream(libResPath);
+        if (in == null) { throw new IllegalStateException("Native library not found at " + libResPath); }
+
+        FileOutputStream out = new FileOutputStream(targetFile);
+        try {
+            byte[] buffer = new byte[1024];
+            int bytesRead = 0;
+            while ((bytesRead = in.read(buffer)) != -1) {
+                out.write(buffer, 0, bytesRead);
+            }
+        }
+        finally {
+            out.close();
+            in.close();
+        }
+
+        // On non-windows systems set up permissions for the extracted native library.
+        if (!System.getProperty("os.name").toLowerCase().contains("windows")) {
+            Runtime.getRuntime().exec(
+                    new String[]{"chmod", "755", targetFile.getAbsolutePath()}).waitFor();
+        }
+        return targetFile;
+    }
+
+    @NonNull
+    private static String getLibraryResourcePath(@NonNull String libraryName) {
+        // Root native library folder.
+        String path = LIBS_RES_PATH;
+
+        // OS:
+        String osName = System.getProperty("os.name");
+        if (osName.contains("Linux")) { path += "/linux"; }
+        else if (osName.contains("Mac")) { path += "/osx"; }
+        else if (osName.contains("Windows")) { path += "/windows"; }
+        else { path += '/' + osName.replaceAll("\\W", "").toLowerCase(); }
+
+        // Arch:
+        String archName = System.getProperty("os.arch");
+        archName = archName.replaceAll("\\W", "");
+        archName = archName.replace("-", "_");
+        path += '/' + archName;
+
+        // Platform specific name part of path.
+        path += '/' + System.mapLibraryName(libraryName);
+        return path;
+    }
+
+    NativeLibraryLoader() { }
+}


### PR DESCRIPTION
* Native libraries including CBL-JNI and LiteCore shared library will be extracted to system-temp-director/com.couchbase.lite.java and being loaded from that location.
* If there is an existing library, NativeLibraryLoader will simply delete the existing ones first. We can enhance this later to also check whether the existing and the new ones are the same (e.g. using MD5).
* Implemented CouchbaseLite class except getExecutionService() method which will be done in separated commit.