### PR TITLE
Implement ConsoleLogger for Java (CBL-166)

### DIFF
--- a/src/ce/java/com/couchbase/lite/ConsoleLogger.java
+++ b/src/ce/java/com/couchbase/lite/ConsoleLogger.java
@@ -1,4 +1,6 @@
 //
+// ConsoleLogger.java
+//
 // Copyright (c) 2019 Couchbase, Inc All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
@@ -17,14 +19,17 @@ package com.couchbase.lite;
 
 import android.support.annotation.NonNull;
 
+import java.io.PrintStream;
 
-public class ConsoleLogger implements Logger {
-    @NonNull
+/**
+ * A class for sending log messages to standard output stream.  This is useful
+ * for debugging during development, but is recommended to be disabled in production (the
+ * file logger is both more durable and more efficient)
+ */
+public class ConsoleLogger extends AbstractConsoleLogger {
     @Override
-    public LogLevel getLevel() {
-        return LogLevel.DEBUG;
+    public void doLog(@NonNull LogLevel level, @NonNull LogDomain domain, @NonNull String message) {
+        PrintStream ps = (level == LogLevel.ERROR) ? System.err : System.out;
+        ps.println(level + "/CouchbaseLite/" + domain + ":" + message);
     }
-
-    @Override
-    public void log(@NonNull LogLevel level, @NonNull LogDomain domain, @NonNull String message) { }
 }

--- a/src/main/java/com/couchbase/lite/AbstractConsoleLogger.java
+++ b/src/main/java/com/couchbase/lite/AbstractConsoleLogger.java
@@ -20,6 +20,7 @@ package com.couchbase.lite;
 import android.support.annotation.NonNull;
 
 import com.couchbase.lite.internal.core.C4Log;
+import com.couchbase.lite.internal.utils.Preconditions;
 
 import java.util.EnumSet;
 
@@ -34,8 +35,7 @@ abstract class AbstractConsoleLogger implements Logger {
     AbstractConsoleLogger() { }
 
     /**
-     * Gets the domains that will be considered for writing to
-     * the Android system log
+     * Gets the domains that will be considered for writing to the console log.
      *
      * @return The currently active domains
      */
@@ -45,19 +45,18 @@ abstract class AbstractConsoleLogger implements Logger {
     }
 
     /**
-     * Sets the domains that will be considered for writing to
-     * the Android system log
+     * Sets the domains that will be considered for writing to the console log.
      *
      * @param domains The domains to make active
      */
     public void setDomains(@NonNull EnumSet<LogDomain> domains) {
-        if (domains == null) { throw new IllegalArgumentException("domains cannot be null."); }
+        Preconditions.checkArgNotNull(domains, "domains");
 
         logDomains = domains;
     }
 
     private void setCallbackLevel(@NonNull LogLevel level) {
-        if (level == null) { throw new IllegalArgumentException("level cannot be null."); }
+        Preconditions.checkArgNotNull(level, "level");
 
         LogLevel callbackLevel = level;
         final Logger custom = Database.log.getCustom();
@@ -75,13 +74,12 @@ abstract class AbstractConsoleLogger implements Logger {
     }
 
     /**
-     * Sets the overall logging level that will be written to
-     * the Android system log
+     * Sets the overall logging level that will be written to the console log.
      *
      * @param level The maximum level to include in the logs
      */
     public void setLevel(@NonNull LogLevel level) {
-        if (level == null) { throw new IllegalArgumentException("level cannot be null."); }
+        Preconditions.checkArgNotNull(level, "level");
 
         if (logLevel == level) { return; }
 

--- a/src/main/java/com/couchbase/lite/AbstractConsoleLogger.java
+++ b/src/main/java/com/couchbase/lite/AbstractConsoleLogger.java
@@ -1,0 +1,103 @@
+//
+// AbstractConsoleLogger.java
+//
+// Copyright (c) 2019 Couchbase, Inc All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+package com.couchbase.lite;
+
+import android.support.annotation.NonNull;
+
+import com.couchbase.lite.internal.core.C4Log;
+
+import java.util.EnumSet;
+
+/**
+ * The base console logger class.
+ */
+abstract class AbstractConsoleLogger implements Logger {
+    private LogLevel logLevel = LogLevel.WARNING;
+    private EnumSet<LogDomain> logDomains = EnumSet.of(LogDomain.ALL);
+
+    // Singleton instance accessible from Log.getConsole()
+    AbstractConsoleLogger() { }
+
+    /**
+     * Gets the domains that will be considered for writing to
+     * the Android system log
+     *
+     * @return The currently active domains
+     */
+    @NonNull
+    public EnumSet<LogDomain> getDomains() {
+        return logDomains;
+    }
+
+    /**
+     * Sets the domains that will be considered for writing to
+     * the Android system log
+     *
+     * @param domains The domains to make active
+     */
+    public void setDomains(@NonNull EnumSet<LogDomain> domains) {
+        if (domains == null) { throw new IllegalArgumentException("domains cannot be null."); }
+
+        logDomains = domains;
+    }
+
+    private void setCallbackLevel(@NonNull LogLevel level) {
+        if (level == null) { throw new IllegalArgumentException("level cannot be null."); }
+
+        LogLevel callbackLevel = level;
+        final Logger custom = Database.log.getCustom();
+        if ((custom != null) && (custom.getLevel().compareTo(callbackLevel) < 0)) {
+            callbackLevel = custom.getLevel();
+        }
+
+        C4Log.setCallbackLevel(callbackLevel.getValue());
+    }
+
+    @NonNull
+    @Override
+    public LogLevel getLevel() {
+        return logLevel;
+    }
+
+    /**
+     * Sets the overall logging level that will be written to
+     * the Android system log
+     *
+     * @param level The maximum level to include in the logs
+     */
+    public void setLevel(@NonNull LogLevel level) {
+        if (level == null) { throw new IllegalArgumentException("level cannot be null."); }
+
+        if (logLevel == level) { return; }
+
+        logLevel = level;
+        setCallbackLevel(level);
+    }
+
+    @Override
+    public void log(LogLevel level, @NonNull LogDomain domain, @NonNull String message) {
+        if (level.compareTo(logLevel) < 0
+                || (!logDomains.contains(domain)
+                && !logDomains.contains(LogDomain.ALL))) {
+            return;
+        }
+        doLog(level, domain, message);
+    }
+
+    protected abstract void doLog(LogLevel level, @NonNull LogDomain domain, @NonNull String message);
+}

--- a/src/main/java/com/couchbase/lite/LogLevel.java
+++ b/src/main/java/com/couchbase/lite/LogLevel.java
@@ -62,4 +62,17 @@ public enum LogLevel {
     public int getValue() {
         return value;
     }
+
+    @Override
+    public String toString() {
+        switch(this) {
+            case DEBUG: return "D";
+            case VERBOSE: return "V";
+            case INFO: return "I";
+            case WARNING: return "W";
+            case ERROR: return "E";
+            case NONE: return "";
+            default: throw new IllegalArgumentException();
+        }
+    }
 }


### PR DESCRIPTION
* Extracted shared logic b/w Android and Java ConsoleLogger into AbstractConsoleLogger class.
* Implemented ConsoleLogger for Java by writing logs to System.out or System.err for errors.
* Added toString() implementation to LogLevel; the returned strings are inline to what Android’s log levels are printed to LogCat.