### PR TITLE
CBL-223: fix: main executor was using thread pool

### DIFF
--- a/src/main/java/com/couchbase/lite/internal/JavaExecutionService.java
+++ b/src/main/java/com/couchbase/lite/internal/JavaExecutionService.java
@@ -70,7 +70,7 @@ public class JavaExecutionService extends AbstractExecutionService {
     private final ScheduledExecutorService scheduler;
 
     public JavaExecutionService() {
-        mainExecutor = getSerialExecutor();
+        mainExecutor = Executors.newSingleThreadExecutor();
         scheduler = Executors.newSingleThreadScheduledExecutor();
     }
 

--- a/src/shared/test/java/com/couchbase/lite/internal/ExecutionServicesTest.kt
+++ b/src/shared/test/java/com/couchbase/lite/internal/ExecutionServicesTest.kt
@@ -260,8 +260,8 @@ class ExecutionServicesTest {
         try { assertTrue(finishLatch.await(5, TimeUnit.SECONDS)) }
         catch (ignore: InterruptedException) { }
 
-        // within 10% is good enough
-        assertEquals((t - 777) / 10, 0L)
+        // within 10% is good enough for MacOS (30% for windows)
+        assertEquals((t - 777) / 30, 0L)
         assertEquals(threads[0], threads[1])
     }
 

--- a/src/shared/test/java/com/couchbase/lite/internal/ExecutionServicesTest.kt
+++ b/src/shared/test/java/com/couchbase/lite/internal/ExecutionServicesTest.kt
@@ -247,8 +247,9 @@ class ExecutionServicesTest {
         executor.execute { threads[0] = Thread.currentThread() }
 
         var t = System.currentTimeMillis()
+        var delay: Long = 777;
         executionService.postDelayedOnExecutor(
-                777,
+                delay,
                 executor,
                 Runnable {
                     t = System.currentTimeMillis() - t
@@ -259,8 +260,8 @@ class ExecutionServicesTest {
         try { assertTrue(finishLatch.await(5, TimeUnit.SECONDS)) }
         catch (ignore: InterruptedException) { }
 
-        // within ~10% is good enough
-        assertEquals(0L, (t - 777) / 80)
+        // within 10% is good enough
+        assertEquals(0L, (t - delay) / (delay / 10))
         assertEquals(threads[0], threads[1])
     }
 

--- a/src/shared/test/java/com/couchbase/lite/internal/ExecutionServicesTest.kt
+++ b/src/shared/test/java/com/couchbase/lite/internal/ExecutionServicesTest.kt
@@ -259,8 +259,8 @@ class ExecutionServicesTest {
         try { assertTrue(finishLatch.await(5, TimeUnit.SECONDS)) }
         catch (ignore: InterruptedException) { }
 
-        // within 10% is good enough for MacOS (30% for windows)
-        assertEquals((t - 777) / 30, 0L)
+        // within ~10% is good enough
+        assertEquals(0L, (t - 777) / 80)
         assertEquals(threads[0], threads[1])
     }
 

--- a/src/shared/test/java/com/couchbase/lite/internal/ExecutionServicesTest.kt
+++ b/src/shared/test/java/com/couchbase/lite/internal/ExecutionServicesTest.kt
@@ -239,7 +239,6 @@ class ExecutionServicesTest {
         val finishLatch = CountDownLatch(1)
 
         val threads = arrayOfNulls<Thread>(2)
-        val executionTime = LongArray(1)
 
         val executor = executionService.mainExecutor
 


### PR DESCRIPTION
* corrected the main executor to use single thread executor
* corrected the timing for windows, since it takes 20milli-seconds extra to load and execute the task. 777 delay will turn to 797 delay in current windows machine.