### PR TITLE
CBL-273 : Add an internal API for restarting concurrent executor

### DIFF
--- a/src/shared/main/java/com/couchbase/lite/internal/AbstractExecutionService.java
+++ b/src/shared/main/java/com/couchbase/lite/internal/AbstractExecutionService.java
@@ -18,6 +18,7 @@
 package com.couchbase.lite.internal;
 
 import android.support.annotation.NonNull;
+import android.support.annotation.VisibleForTesting;
 
 import java.util.ArrayDeque;
 import java.util.concurrent.CountDownLatch;
@@ -74,7 +75,7 @@ public abstract class AbstractExecutionService implements ExecutionService {
             if (latch != null) { latch.countDown(); }
         }
 
-        /* For tests to restart the concurrent executor after stopping it. */
+        @VisibleForTesting
         private void restart() {
             synchronized (this) {
                 if (stopLatch == null || running > 0) {
@@ -167,7 +168,7 @@ public abstract class AbstractExecutionService implements ExecutionService {
         return concurrentExecutor;
     }
 
-    /* For tests to restart the concurrent executor after stopping it. */
+    @VisibleForTesting
     void restartConcurrentExecutor() {
         ((ConcurrentExecutor) concurrentExecutor).restart();
     }

--- a/src/shared/main/java/com/couchbase/lite/internal/AbstractExecutionService.java
+++ b/src/shared/main/java/com/couchbase/lite/internal/AbstractExecutionService.java
@@ -73,6 +73,18 @@ public abstract class AbstractExecutionService implements ExecutionService {
 
             if (latch != null) { latch.countDown(); }
         }
+
+        /* For tests to restart the concurrent executor after stopping it. */
+        private void restart() {
+            synchronized (this) {
+                if (stopLatch == null || running > 0) {
+                    throw new IllegalStateException("Executor hasn't been stopped yet.");
+                }
+
+                stopLatch = null;
+                running = 0;
+            }
+        }
     }
 
     // Patterned after AsyncTask's executor
@@ -153,5 +165,10 @@ public abstract class AbstractExecutionService implements ExecutionService {
     @Override
     public CloseableExecutor getConcurrentExecutor() {
         return concurrentExecutor;
+    }
+
+    /* For tests to restart the concurrent executor after stopping it. */
+    void restartConcurrentExecutor() {
+        ((ConcurrentExecutor) concurrentExecutor).restart();
     }
 }


### PR DESCRIPTION
* The concurrent executor is shared so it is needed to be restarted when tests stop it. The issue didn’t happen on CBL Android because somehow the CBL Android tests get executed in an order that doesn’t cause the problem.

* Added AbstractExecutorService’s restartConcurrentExecutor() method that will call the restart() method of the ConcurrentExecutor.