### PR TITLE
CBL-442 (partial): enable standard error messages

### DIFF
--- a/src/shared/main/java/com/couchbase/lite/CBLError.java
+++ b/src/shared/main/java/com/couchbase/lite/CBLError.java
@@ -4,7 +4,7 @@
 // Copyright (c) 2017 Couchbase, Inc All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License")
-    // you may not use this file except in compliance with the License.
+// you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
 // http://www.apache.org/licenses/LICENSE-2.0
@@ -17,16 +17,8 @@
 //
 package com.couchbase.lite;
 
-import java.util.FormatterClosedException;
-import java.util.IllegalFormatException;
-import java.util.Map;
-import java.util.concurrent.atomic.AtomicReference;
-
-
 @SuppressWarnings("LineLength")
 public final class CBLError {
-    private static final AtomicReference<Map<String, String>> ERROR_MESSAGES = new AtomicReference<>();
-
     private CBLError() {}
 
     // Error Domain
@@ -42,6 +34,7 @@ public final class CBLError {
     public static final class Code {
         private Code() {}
 
+        // @formatter:off
         public static final int ASSERTION_FAILED = 1;                    // Internal assertion failure
         public static final int UNIMPLEMENTED = 2;                       // Oops, an unimplemented API call
         public static final int UNSUPPORTED_ENCRYPTION = 3;              // Unsupported encryption algorithm
@@ -72,7 +65,7 @@ public final class CBLError {
         public static final int REMOTE_ERROR = 26;                       // Unknown error from remote server
         public static final int DATABASE_TOO_OLD = 27;                   // Database file format is older than what I can open
         public static final int DATABASE_TOO_NEW = 28;                   // Database file format is newer than what I can open
-        public static final int BAD_DOC_ID = 29;                        // Invalid document ID
+        public static final int BAD_DOC_ID = 29;                         // Invalid document ID
         public static final int CANT_UPGRADE_DATABASE = 30;              // Database can't be upgraded (might be unsupported dev version)
         // Note: These are equivalent to the C4Error codes declared in LiteCore's c4Base.h
 
@@ -117,19 +110,6 @@ public final class CBLError {
         public static final int WEB_SOCKET_CANT_FULFILL = 11011;         // Can't fulfill request due to "unexpected condition"
         public static final int WEB_SOCKET_CLOSE_USER_TRANSIENT = 14001; // Recoverable messaging error
         public static final int WEB_SOCKET_CLOSE_USER_PERMANENT = 14002; // Non-recoverable messaging error
-    }
-
-    static void setErrorMessages(Map<String, String> errorMessages) {
-        ERROR_MESSAGES.set(errorMessages);
-    }
-
-    static String lookupErrorMessage(String error, String... args) {
-        final String message = ERROR_MESSAGES.get().get(error);
-        if (message == null) { return error; }
-
-        try { return String.format(message, (Object[]) args); }
-        catch (IllegalFormatException | FormatterClosedException ignore) { }
-
-        return error;
+        // @formatter:on
     }
 }

--- a/src/shared/main/java/com/couchbase/lite/LogFileConfiguration.java
+++ b/src/shared/main/java/com/couchbase/lite/LogFileConfiguration.java
@@ -183,7 +183,7 @@ public final class LogFileConfiguration {
     public boolean equals(Object o) {
         if (this == o) { return true; }
         if (!(o instanceof LogFileConfiguration)) { return false; }
-        LogFileConfiguration that = (LogFileConfiguration) o;
+        final LogFileConfiguration that = (LogFileConfiguration) o;
         return (maxRotateCount == that.maxRotateCount)
             && directory.equals(that.directory)
             && (maxSize == that.maxSize)

--- a/src/shared/main/java/com/couchbase/lite/internal/support/Log.java
+++ b/src/shared/main/java/com/couchbase/lite/internal/support/Log.java
@@ -18,11 +18,13 @@
 package com.couchbase.lite.internal.support;
 
 import android.support.annotation.NonNull;
+import android.support.annotation.Nullable;
 
 import java.util.Collections;
 import java.util.EnumSet;
+import java.util.FormatterClosedException;
 import java.util.HashMap;
-import java.util.Locale;
+import java.util.IllegalFormatException;
 import java.util.Map;
 
 import com.couchbase.lite.ConsoleLogger;
@@ -72,11 +74,16 @@ public final class Log {
         LOG_LEVEL_FROM_C4 = Collections.unmodifiableMap(m);
     }
 
+    private static volatile Map<String, String> errorMessages;
+
     /**
      * Setup logging.
      */
-    public static void initLogging() {
+    public static void initLogging(@NonNull Map<String, String> errorMessages) {
         setC4LogLevel(LogDomain.ALL_DOMAINS, LogLevel.DEBUG);
+
+        Log.errorMessages = Collections.unmodifiableMap(errorMessages);
+
         Log.i(LogDomain.DATABASE, "Couchbase Lite initialized: " + CBLVersion.getVersionInfo());
     }
 
@@ -86,53 +93,36 @@ public final class Log {
      * @param domain The log domain.
      * @param msg    The message you would like logged.
      */
-    public static void d(LogDomain domain, String msg) { sendToLoggers(LogLevel.DEBUG, domain, msg); }
+    public static void d(LogDomain domain, String msg) { log(LogLevel.DEBUG, domain, null, msg); }
 
     /**
      * Send a DEBUG message and log the exception.
      *
      * @param domain The log domain.
      * @param msg    The message you would like logged.
-     * @param tr     An exception to log
+     * @param err    An exception to log
      */
-    public static void d(LogDomain domain, String msg, Throwable tr) {
-        d(domain, msg + ".  Exception: %s", tr.toString());
-    }
+    public static void d(LogDomain domain, String msg, Throwable err) { log(LogLevel.DEBUG, domain, err, msg); }
 
     /**
      * Send a DEBUG message.
      *
-     * @param domain       The log domain.
-     * @param formatString The string you would like logged plus format specifiers.
-     * @param args         Variable number of Object args to be used as params to formatString.
+     * @param domain The log domain.
+     * @param msg    The string you would like logged plus format specifiers.
+     * @param args   Variable number of Object args to be used as params to formatString.
      */
-    public static void d(LogDomain domain, String formatString, Object... args) {
-        String msg;
-        try { msg = String.format(Locale.ENGLISH, formatString, args); }
-        catch (Exception e) {
-            msg = String.format(Locale.ENGLISH, "Unable to format log: %s (%s)", formatString, e.toString());
-        }
-        sendToLoggers(LogLevel.DEBUG, domain, msg);
-    }
+    public static void d(LogDomain domain, String msg, Object... args) { log(LogLevel.DEBUG, domain, null, msg, args); }
 
     /**
      * Send a DEBUG message and log the exception.
      *
-     * @param domain       The log domain.
-     * @param formatString The string you would like logged plus format specifiers.
-     * @param tr           An exception to log
-     * @param args         Variable number of Object args to be used as params to formatString.
+     * @param domain The log domain.
+     * @param msg    The string you would like logged plus format specifiers.
+     * @param err    An exception to log
+     * @param args   Variable number of Object args to be used as params to formatString.
      */
-    public static void d(LogDomain domain, String formatString, Throwable tr, Object... args) {
-        String msg;
-        try {
-            msg = String.format(formatString, args);
-            msg = String.format("%s (%s)", msg, tr.toString());
-        }
-        catch (Exception e) {
-            msg = String.format(Locale.ENGLISH, "Unable to format log: %s (%s)", formatString, e.toString());
-        }
-        sendToLoggers(LogLevel.DEBUG, domain, msg);
+    public static void d(LogDomain domain, String msg, Throwable err, Object... args) {
+        log(LogLevel.DEBUG, domain, err, msg, args);
     }
 
     /**
@@ -141,53 +131,38 @@ public final class Log {
      * @param domain The log domain.
      * @param msg    The message you would like logged.
      */
-    public static void v(LogDomain domain, String msg) { sendToLoggers(LogLevel.VERBOSE, domain, msg); }
+    public static void v(LogDomain domain, String msg) { log(LogLevel.VERBOSE, domain, null, msg); }
 
     /**
      * Send a VERBOSE message and log the exception.
      *
      * @param domain The log domain.
      * @param msg    The message you would like logged.
-     * @param tr     An exception to log
+     * @param err    An exception to log
      */
-    public static void v(LogDomain domain, String msg, Throwable tr) {
-        v(domain, msg + ".  Exception: %s", tr.toString());
-    }
+    public static void v(LogDomain domain, String msg, Throwable err) { log(LogLevel.VERBOSE, domain, err, msg); }
 
     /**
      * Send a VERBOSE message.
      *
-     * @param domain       The log domain.
-     * @param formatString The string you would like logged plus format specifiers.
-     * @param args         Variable number of Object args to be used as params to formatString.
+     * @param domain The log domain.
+     * @param msg    The string you would like logged plus format specifiers.
+     * @param args   Variable number of Object args to be used as params to formatString.
      */
-    public static void v(LogDomain domain, String formatString, Object... args) {
-        String msg;
-        try { msg = String.format(Locale.ENGLISH, formatString, args); }
-        catch (Exception e) {
-            msg = String.format(Locale.ENGLISH, "Unable to format log: %s (%s)", formatString, e.toString());
-        }
-        sendToLoggers(LogLevel.VERBOSE, domain, msg);
+    public static void v(LogDomain domain, String msg, Object... args) {
+        log(LogLevel.VERBOSE, domain, null, msg, args);
     }
 
     /**
      * Send a VERBOSE message and log the exception.
      *
-     * @param domain       The log domain.
-     * @param formatString The string you would like logged plus format specifiers.
-     * @param tr           An exception to log
-     * @param args         Variable number of Object args to be used as params to formatString.
+     * @param domain The log domain.
+     * @param msg    The string you would like logged plus format specifiers.
+     * @param err    An exception to log
+     * @param args   Variable number of Object args to be used as params to formatString.
      */
-    public static void v(LogDomain domain, String formatString, Throwable tr, Object... args) {
-        String msg;
-        try {
-            msg = String.format(formatString, args);
-            msg = String.format("%s (%s)", msg, tr.toString());
-        }
-        catch (Exception e) {
-            msg = String.format(Locale.ENGLISH, "Unable to format log: %s (%s)", formatString, e.toString());
-        }
-        sendToLoggers(LogLevel.VERBOSE, domain, msg);
+    public static void v(LogDomain domain, String msg, Throwable err, Object... args) {
+        log(LogLevel.VERBOSE, domain, err, msg, args);
     }
 
     /**
@@ -196,57 +171,40 @@ public final class Log {
      * @param domain The log domain.
      * @param msg    The message you would like logged.
      */
-    public static void i(LogDomain domain, String msg) { sendToLoggers(LogLevel.INFO, domain, msg); }
+    public static void i(LogDomain domain, String msg) { log(LogLevel.INFO, domain, null, msg); }
+
+    public static void info(LogDomain domain, String msg) { i(domain, msg); }
 
     /**
      * Send a INFO message and log the exception.
      *
      * @param domain The log domain.
      * @param msg    The message you would like logged.
-     * @param tr     An exception to log
+     * @param err    An exception to log
      */
-    public static void i(LogDomain domain, String msg, Throwable tr) {
-        i(domain, msg + ".  Exception: %s", tr.toString());
-    }
-
-    public static void info(LogDomain domain, String msg) { i(domain, msg); }
+    public static void i(LogDomain domain, String msg, Throwable err) { log(LogLevel.INFO, domain, err, msg); }
 
     public static void info(LogDomain domain, String msg, Throwable tr) { i(domain, msg, tr); }
 
     /**
      * Send an INFO message.
      *
-     * @param domain       The log domain.
-     * @param formatString The string you would like logged plus format specifiers.
-     * @param args         Variable number of Object args to be used as params to formatString.
+     * @param domain The log domain.
+     * @param msg    The string you would like logged plus format specifiers.
+     * @param args   Variable number of Object args to be used as params to formatString.
      */
-    public static void i(LogDomain domain, String formatString, Object... args) {
-        String msg;
-        try { msg = String.format(Locale.ENGLISH, formatString, args); }
-        catch (Exception e) {
-            msg = String.format(Locale.ENGLISH, "Unable to format log: %s (%s)", formatString, e.toString());
-        }
-        sendToLoggers(LogLevel.INFO, domain, msg);
-    }
+    public static void i(LogDomain domain, String msg, Object... args) { log(LogLevel.INFO, domain, null, msg, args); }
 
     /**
      * Send a INFO message and log the exception.
      *
-     * @param domain       The log domain.
-     * @param formatString The string you would like logged plus format specifiers.
-     * @param tr           An exception to log
-     * @param args         Variable number of Object args to be used as params to formatString.
+     * @param domain The log domain.
+     * @param msg    The string you would like logged plus format specifiers.
+     * @param err    An exception to log
+     * @param args   Variable number of Object args to be used as params to formatString.
      */
-    public static void i(LogDomain domain, String formatString, Throwable tr, Object... args) {
-        String msg;
-        try {
-            msg = String.format(formatString, args);
-            msg = String.format("%s (%s)", msg, tr.toString());
-        }
-        catch (Exception e) {
-            msg = String.format(Locale.ENGLISH, "Unable to format log: %s (%s)", formatString, e.toString());
-        }
-        sendToLoggers(LogLevel.INFO, domain, msg);
+    public static void i(LogDomain domain, String msg, Throwable err, Object... args) {
+        log(LogLevel.INFO, domain, err, msg, args);
     }
 
     /**
@@ -255,59 +213,38 @@ public final class Log {
      * @param domain The log domain.
      * @param msg    The message you would like logged.
      */
-    public static void w(LogDomain domain, String msg) { sendToLoggers(LogLevel.WARNING, domain, msg); }
-
-    /**
-     * Send a WARN message and log the exception.
-     *
-     * @param domain The log domain.
-     * @param tr     An exception to log
-     */
-    public static void w(LogDomain domain, Throwable tr) { w(domain, "Exception: %s", tr.toString()); }
+    public static void w(LogDomain domain, String msg) { log(LogLevel.WARNING, domain, null, msg); }
 
     /**
      * Send a WARN message and log the exception.
      *
      * @param domain The log domain.
      * @param msg    The message you would like logged.
-     * @param tr     An exception to log
+     * @param err    An exception to log
      */
-    public static void w(LogDomain domain, String msg, Throwable tr) { w(domain, "%s: %s", msg, tr.toString()); }
+    public static void w(LogDomain domain, String msg, Throwable err) { log(LogLevel.WARNING, domain, err, msg); }
 
     /**
      * Send a WARN message.
      *
-     * @param domain       The log domain.
-     * @param formatString The string you would like logged plus format specifiers.
-     * @param args         Variable number of Object args to be used as params to formatString.
+     * @param domain The log domain.
+     * @param msg    The string you would like logged plus format specifiers.
+     * @param args   Variable number of Object args to be used as params to formatString.
      */
-    public static void w(LogDomain domain, String formatString, Object... args) {
-        String msg;
-        try { msg = String.format(Locale.ENGLISH, formatString, args); }
-        catch (Exception e) {
-            msg = String.format(Locale.ENGLISH, "Unable to format log: %s (%s)", formatString, e.toString());
-        }
-        sendToLoggers(LogLevel.WARNING, domain, msg);
+    public static void w(LogDomain domain, String msg, Object... args) {
+        log(LogLevel.WARNING, domain, null, msg, args);
     }
 
     /**
      * Send a WARN message and log the exception.
      *
-     * @param domain       The log domain.
-     * @param formatString The string you would like logged plus format specifiers.
-     * @param tr           An exception to log
-     * @param args         Variable number of Object args to be used as params to formatString.
+     * @param domain The log domain.
+     * @param msg    The string you would like logged plus format specifiers.
+     * @param err    An exception to log
+     * @param args   Variable number of Object args to be used as params to formatString.
      */
-    public static void w(LogDomain domain, String formatString, Throwable tr, Object... args) {
-        String msg;
-        try {
-            msg = String.format(formatString, args);
-            msg = String.format("%s (%s)", msg, tr.toString());
-        }
-        catch (Exception e) {
-            msg = String.format(Locale.ENGLISH, "Unable to format log: %s (%s)", formatString, e.toString());
-        }
-        sendToLoggers(LogLevel.WARNING, domain, msg);
+    public static void w(LogDomain domain, String msg, Throwable err, Object... args) {
+        log(LogLevel.WARNING, domain, err, msg, args);
     }
 
     /**
@@ -316,51 +253,38 @@ public final class Log {
      * @param domain The log domain.
      * @param msg    The message you would like logged.
      */
-    public static void e(LogDomain domain, String msg) { sendToLoggers(LogLevel.ERROR, domain, msg); }
+    public static void e(LogDomain domain, String msg) { log(LogLevel.ERROR, domain, null, msg); }
 
     /**
      * Send a ERROR message and log the exception.
      *
      * @param domain The log domain.
      * @param msg    The message you would like logged.
-     * @param tr     An exception to log
+     * @param err    An exception to log
      */
-    public static void e(LogDomain domain, String msg, Throwable tr) { e(domain, "%s: %s", msg, tr.toString()); }
-
-    /**
-     * Send a ERROR message and log the exception.
-     *
-     * @param domain       The log domain.
-     * @param formatString The string you would like logged plus format specifiers.
-     * @param tr           An exception to log
-     * @param args         Variable number of Object args to be used as params to formatString.
-     */
-    public static void e(LogDomain domain, String formatString, Throwable tr, Object... args) {
-        String msg;
-        try {
-            msg = String.format(formatString, args);
-            msg = String.format("%s (%s)", msg, tr.toString());
-        }
-        catch (Exception e) {
-            msg = String.format(Locale.ENGLISH, "Unable to format log: %s (%s)", formatString, e.toString());
-        }
-        sendToLoggers(LogLevel.ERROR, domain, msg);
-    }
+    public static void e(LogDomain domain, String msg, Throwable err) { log(LogLevel.ERROR, domain, err, msg); }
 
     /**
      * Send a ERROR message.
      *
-     * @param domain       The log domain.
-     * @param formatString The string you would like logged plus format specifiers.
-     * @param args         Variable number of Object args to be used as params to formatString.
+     * @param domain The log domain.
+     * @param msg    The string you would like logged plus format specifiers.
+     * @param args   Variable number of Object args to be used as params to formatString.
      */
-    public static void e(LogDomain domain, String formatString, Object... args) {
-        String msg;
-        try { msg = String.format(Locale.ENGLISH, formatString, args); }
-        catch (Exception e) {
-            msg = String.format(Locale.ENGLISH, "Unable to format log: %s (%s)", formatString, e.toString());
-        }
-        sendToLoggers(LogLevel.ERROR, domain, msg);
+    public static void e(LogDomain domain, String msg, Object... args) {
+        log(LogLevel.ERROR, domain, null, msg, args);
+    }
+
+    /**
+     * Send a ERROR message and log the exception.
+     *
+     * @param domain The log domain.
+     * @param msg    The string you would like logged plus format specifiers.
+     * @param err    An exception to log
+     * @param args   Variable number of Object args to be used as params to formatString.
+     */
+    public static void e(LogDomain domain, String msg, Throwable err, Object... args) {
+        log(LogLevel.ERROR, domain, err, msg, args);
     }
 
     @NonNull
@@ -406,6 +330,32 @@ public final class Log {
                     break;
             }
         }
+    }
+
+    private static void log(
+        @NonNull LogLevel level,
+        @NonNull LogDomain domain,
+        @Nullable Throwable err,
+        @Nullable String msg,
+        Object... args) {
+        String message = lookupErrorMessage(msg);
+
+        if ((args != null) && (args.length > 0)) { message = formatMessage(message, args); }
+
+        if (err != null) { message = message + " (" + err + ")"; }
+
+        sendToLoggers(level, domain, message);
+    }
+
+    private static String lookupErrorMessage(String error) {
+        final String message = errorMessages.get(error);
+        return (message == null) ? error : message;
+    }
+
+    private static String formatMessage(String msg, Object... args) {
+        try { return String.format(msg, (Object[]) args); }
+        catch (IllegalFormatException | FormatterClosedException ignore) { }
+        return msg;
     }
 
     private static void sendToLoggers(LogLevel level, LogDomain domain, String msg) {

--- a/src/shared/main/java/com/couchbase/lite/internal/support/Log.java
+++ b/src/shared/main/java/com/couchbase/lite/internal/support/Log.java
@@ -25,6 +25,7 @@ import java.util.EnumSet;
 import java.util.FormatterClosedException;
 import java.util.HashMap;
 import java.util.IllegalFormatException;
+import java.util.Locale;
 import java.util.Map;
 
 import com.couchbase.lite.ConsoleLogger;
@@ -93,7 +94,7 @@ public final class Log {
      * @param domain The log domain.
      * @param msg    The message you would like logged.
      */
-    public static void d(LogDomain domain, String msg) { log(LogLevel.DEBUG, domain, null, msg); }
+    public static void d(@NonNull LogDomain domain, @NonNull String msg) { log(LogLevel.DEBUG, domain, null, msg); }
 
     /**
      * Send a DEBUG message and log the exception.
@@ -102,7 +103,9 @@ public final class Log {
      * @param msg    The message you would like logged.
      * @param err    An exception to log
      */
-    public static void d(LogDomain domain, String msg, Throwable err) { log(LogLevel.DEBUG, domain, err, msg); }
+    public static void d(@NonNull LogDomain domain, @NonNull String msg, @NonNull Throwable err) {
+        log(LogLevel.DEBUG, domain, err, msg);
+    }
 
     /**
      * Send a DEBUG message.
@@ -111,7 +114,9 @@ public final class Log {
      * @param msg    The string you would like logged plus format specifiers.
      * @param args   Variable number of Object args to be used as params to formatString.
      */
-    public static void d(LogDomain domain, String msg, Object... args) { log(LogLevel.DEBUG, domain, null, msg, args); }
+    public static void d(@NonNull LogDomain domain, @NonNull String msg, Object... args) {
+        log(LogLevel.DEBUG, domain, null, msg, args);
+    }
 
     /**
      * Send a DEBUG message and log the exception.
@@ -121,7 +126,7 @@ public final class Log {
      * @param err    An exception to log
      * @param args   Variable number of Object args to be used as params to formatString.
      */
-    public static void d(LogDomain domain, String msg, Throwable err, Object... args) {
+    public static void d(@NonNull LogDomain domain, @NonNull String msg, @NonNull Throwable err, Object... args) {
         log(LogLevel.DEBUG, domain, err, msg, args);
     }
 
@@ -131,7 +136,7 @@ public final class Log {
      * @param domain The log domain.
      * @param msg    The message you would like logged.
      */
-    public static void v(LogDomain domain, String msg) { log(LogLevel.VERBOSE, domain, null, msg); }
+    public static void v(@NonNull LogDomain domain, @NonNull String msg) { log(LogLevel.VERBOSE, domain, null, msg); }
 
     /**
      * Send a VERBOSE message and log the exception.
@@ -140,7 +145,9 @@ public final class Log {
      * @param msg    The message you would like logged.
      * @param err    An exception to log
      */
-    public static void v(LogDomain domain, String msg, Throwable err) { log(LogLevel.VERBOSE, domain, err, msg); }
+    public static void v(@NonNull LogDomain domain, @NonNull String msg, @NonNull Throwable err) {
+        log(LogLevel.VERBOSE, domain, err, msg);
+    }
 
     /**
      * Send a VERBOSE message.
@@ -149,7 +156,7 @@ public final class Log {
      * @param msg    The string you would like logged plus format specifiers.
      * @param args   Variable number of Object args to be used as params to formatString.
      */
-    public static void v(LogDomain domain, String msg, Object... args) {
+    public static void v(@NonNull LogDomain domain, @NonNull String msg, Object... args) {
         log(LogLevel.VERBOSE, domain, null, msg, args);
     }
 
@@ -161,7 +168,7 @@ public final class Log {
      * @param err    An exception to log
      * @param args   Variable number of Object args to be used as params to formatString.
      */
-    public static void v(LogDomain domain, String msg, Throwable err, Object... args) {
+    public static void v(@NonNull LogDomain domain, @NonNull String msg, @NonNull Throwable err, Object... args) {
         log(LogLevel.VERBOSE, domain, err, msg, args);
     }
 
@@ -171,9 +178,9 @@ public final class Log {
      * @param domain The log domain.
      * @param msg    The message you would like logged.
      */
-    public static void i(LogDomain domain, String msg) { log(LogLevel.INFO, domain, null, msg); }
+    public static void i(@NonNull LogDomain domain, @NonNull String msg) { log(LogLevel.INFO, domain, null, msg); }
 
-    public static void info(LogDomain domain, String msg) { i(domain, msg); }
+    public static void info(@NonNull LogDomain domain, @NonNull String msg) { i(domain, msg); }
 
     /**
      * Send a INFO message and log the exception.
@@ -182,9 +189,13 @@ public final class Log {
      * @param msg    The message you would like logged.
      * @param err    An exception to log
      */
-    public static void i(LogDomain domain, String msg, Throwable err) { log(LogLevel.INFO, domain, err, msg); }
+    public static void i(@NonNull LogDomain domain, @NonNull String msg, @NonNull Throwable err) {
+        log(LogLevel.INFO, domain, err, msg);
+    }
 
-    public static void info(LogDomain domain, String msg, Throwable tr) { i(domain, msg, tr); }
+    public static void info(@NonNull LogDomain domain, @NonNull String msg, @NonNull Throwable err) {
+        i(domain, msg, err);
+    }
 
     /**
      * Send an INFO message.
@@ -193,7 +204,9 @@ public final class Log {
      * @param msg    The string you would like logged plus format specifiers.
      * @param args   Variable number of Object args to be used as params to formatString.
      */
-    public static void i(LogDomain domain, String msg, Object... args) { log(LogLevel.INFO, domain, null, msg, args); }
+    public static void i(@NonNull LogDomain domain, @NonNull String msg, Object... args) {
+        log(LogLevel.INFO, domain, null, msg, args);
+    }
 
     /**
      * Send a INFO message and log the exception.
@@ -203,7 +216,7 @@ public final class Log {
      * @param err    An exception to log
      * @param args   Variable number of Object args to be used as params to formatString.
      */
-    public static void i(LogDomain domain, String msg, Throwable err, Object... args) {
+    public static void i(@NonNull LogDomain domain, @NonNull String msg, @NonNull Throwable err, Object... args) {
         log(LogLevel.INFO, domain, err, msg, args);
     }
 
@@ -213,7 +226,7 @@ public final class Log {
      * @param domain The log domain.
      * @param msg    The message you would like logged.
      */
-    public static void w(LogDomain domain, String msg) { log(LogLevel.WARNING, domain, null, msg); }
+    public static void w(@NonNull LogDomain domain, @NonNull String msg) { log(LogLevel.WARNING, domain, null, msg); }
 
     /**
      * Send a WARN message and log the exception.
@@ -222,7 +235,9 @@ public final class Log {
      * @param msg    The message you would like logged.
      * @param err    An exception to log
      */
-    public static void w(LogDomain domain, String msg, Throwable err) { log(LogLevel.WARNING, domain, err, msg); }
+    public static void w(@NonNull LogDomain domain, @NonNull String msg, @NonNull Throwable err) {
+        log(LogLevel.WARNING, domain, err, msg);
+    }
 
     /**
      * Send a WARN message.
@@ -231,7 +246,7 @@ public final class Log {
      * @param msg    The string you would like logged plus format specifiers.
      * @param args   Variable number of Object args to be used as params to formatString.
      */
-    public static void w(LogDomain domain, String msg, Object... args) {
+    public static void w(@NonNull LogDomain domain, @NonNull String msg, Object... args) {
         log(LogLevel.WARNING, domain, null, msg, args);
     }
 
@@ -243,7 +258,7 @@ public final class Log {
      * @param err    An exception to log
      * @param args   Variable number of Object args to be used as params to formatString.
      */
-    public static void w(LogDomain domain, String msg, Throwable err, Object... args) {
+    public static void w(@NonNull LogDomain domain, @NonNull String msg, @NonNull Throwable err, Object... args) {
         log(LogLevel.WARNING, domain, err, msg, args);
     }
 
@@ -253,7 +268,7 @@ public final class Log {
      * @param domain The log domain.
      * @param msg    The message you would like logged.
      */
-    public static void e(LogDomain domain, String msg) { log(LogLevel.ERROR, domain, null, msg); }
+    public static void e(@NonNull LogDomain domain, @NonNull String msg) { log(LogLevel.ERROR, domain, null, msg); }
 
     /**
      * Send a ERROR message and log the exception.
@@ -262,7 +277,9 @@ public final class Log {
      * @param msg    The message you would like logged.
      * @param err    An exception to log
      */
-    public static void e(LogDomain domain, String msg, Throwable err) { log(LogLevel.ERROR, domain, err, msg); }
+    public static void e(@NonNull LogDomain domain, @NonNull String msg, @NonNull Throwable err) {
+        log(LogLevel.ERROR, domain, err, msg);
+    }
 
     /**
      * Send a ERROR message.
@@ -271,7 +288,7 @@ public final class Log {
      * @param msg    The string you would like logged plus format specifiers.
      * @param args   Variable number of Object args to be used as params to formatString.
      */
-    public static void e(LogDomain domain, String msg, Object... args) {
+    public static void e(@NonNull LogDomain domain, @NonNull String msg, Object... args) {
         log(LogLevel.ERROR, domain, null, msg, args);
     }
 
@@ -283,7 +300,7 @@ public final class Log {
      * @param err    An exception to log
      * @param args   Variable number of Object args to be used as params to formatString.
      */
-    public static void e(LogDomain domain, String msg, Throwable err, Object... args) {
+    public static void e(@NonNull LogDomain domain, @NonNull String msg, @NonNull Throwable err, Object... args) {
         log(LogLevel.ERROR, domain, err, msg, args);
     }
 
@@ -294,7 +311,7 @@ public final class Log {
     }
 
     @NonNull
-    public static String getC4DomainForLoggingDomain(LogDomain domain) {
+    public static String getC4DomainForLoggingDomain(@NonNull LogDomain domain) {
         final String c4Domain = LOGGING_DOMAINS_TO_C4.get(domain);
         return (c4Domain != null) ? c4Domain : C4Constants.LogDomain.DATABASE;
     }
@@ -305,7 +322,7 @@ public final class Log {
         return (domain != null) ? domain : LogDomain.DATABASE;
     }
 
-    public static void setC4LogLevel(EnumSet<LogDomain> domains, LogLevel level) {
+    public static void setC4LogLevel(@NonNull EnumSet<LogDomain> domains, @NonNull LogLevel level) {
         final int c4Level = level.getValue();
         for (LogDomain domain : domains) {
             switch (domain) {
@@ -336,9 +353,13 @@ public final class Log {
         @NonNull LogLevel level,
         @NonNull LogDomain domain,
         @Nullable Throwable err,
-        @Nullable String msg,
+        @NonNull String msg,
         Object... args) {
-        String message = lookupErrorMessage(msg);
+        // Don't let logging errors cause an abort
+        if ((level == null) || (domain == null)) { return; }
+        String message = (msg != null) ? msg : "---";
+
+        message = lookupErrorMessage(message);
 
         if ((args != null) && (args.length > 0)) { message = formatMessage(message, args); }
 
@@ -348,12 +369,12 @@ public final class Log {
     }
 
     private static String lookupErrorMessage(String error) {
-        final String message = errorMessages.get(error);
+        final String message = (errorMessages == null) ? null : errorMessages.get(error);
         return (message == null) ? error : message;
     }
 
     private static String formatMessage(String msg, Object... args) {
-        try { return String.format(msg, (Object[]) args); }
+        try { return String.format(Locale.ENGLISH, msg, (Object[]) args); }
         catch (IllegalFormatException | FormatterClosedException ignore) { }
         return msg;
     }

--- a/src/shared/test/java/com/couchbase/lite/LogTest.java
+++ b/src/shared/test/java/com/couchbase/lite/LogTest.java
@@ -1,5 +1,7 @@
 package com.couchbase.lite;
 
+import android.support.annotation.NonNull;
+
 import java.io.BufferedReader;
 import java.io.File;
 import java.io.FileInputStream;
@@ -18,6 +20,7 @@ import org.junit.Test;
 
 import com.couchbase.lite.internal.core.CBLVersion;
 import com.couchbase.lite.internal.support.Log;
+import com.couchbase.lite.utils.TestUtils;
 
 import static com.couchbase.lite.utils.TestUtils.assertThrows;
 import static org.junit.Assert.assertEquals;
@@ -28,8 +31,17 @@ import static org.junit.Assert.assertTrue;
 
 
 public class LogTest extends BaseTest {
-    interface Task {
-        void run() throws Exception;
+    static class BasicLogger implements Logger {
+        private String message;
+
+        @NonNull
+        @Override
+        public LogLevel getLevel() { return LogLevel.DEBUG; }
+
+        @Override
+        public void log(@NonNull LogLevel level, @NonNull LogDomain domain, @NonNull String msg) { message = msg; }
+
+        public String getMessage() { return message; }
     }
 
     static class LogTestLogger implements Logger {
@@ -299,6 +311,38 @@ public class LogTest extends BaseTest {
     }
 
     @Test
+    public void testBasicLogFormatting() {
+        BasicLogger logger = new BasicLogger();
+        Database.log.setCustom(logger);
+
+        Log.d(LogDomain.DATABASE, "TEST DEBUG");
+        assertEquals("TEST DEBUG", logger.getMessage());
+
+        Log.d(LogDomain.DATABASE, "TEST DEBUG", new Exception("whoops"));
+        assertEquals("TEST DEBUG (java.lang.Exception: whoops)", logger.getMessage());
+
+        Log.d(LogDomain.DATABASE, "TEST DEBUG %s %d %f", "arg", 1, 3.0F);
+        assertEquals("TEST DEBUG arg 1 3.000000", logger.getMessage());
+
+        Log.d(LogDomain.DATABASE, "TEST DEBUG %s %d %f", new Exception("whoops"), "arg", 1, 3.0F);
+        assertEquals("TEST DEBUG arg 1 3.000000 (java.lang.Exception: whoops)", logger.getMessage());
+    }
+
+    @Test
+    public void testLogStandardErrorWithFormatting() {
+        Map<String, String> stdErr = new HashMap<>();
+        stdErr.put("FOO", "TEST DEBUG arg 1 3.000000");
+
+        Log.initLogging(stdErr);
+
+        BasicLogger logger = new BasicLogger();
+        Database.log.setCustom(logger);
+
+        Log.d(LogDomain.DATABASE, "FOO", new Exception("whoops"), "arg", 1, 3.0F);
+        assertEquals("TEST DEBUG arg 1 3.000000 (java.lang.Exception: whoops)", logger.getMessage());
+    }
+
+    @Test
     public void testWriteLogWithError() throws Exception {
         String message = "test message";
         String uuid = UUID.randomUUID().toString();
@@ -433,7 +477,8 @@ public class LogTest extends BaseTest {
         assertTrue(customLogger.getContent().contains("[{\"hebrew\":\"" + hebrew + "\"}]"));
     }
 
-    private void testWithConfiguration(LogLevel level, LogFileConfiguration config, Task task) throws Exception {
+    private void testWithConfiguration(LogLevel level, LogFileConfiguration config, TestUtils.Task task)
+        throws Exception {
         final com.couchbase.lite.Log logger = Database.log;
 
         final ConsoleLogger consoleLogger = logger.getConsole();

--- a/src/shared/test/java/com/couchbase/lite/LogTest.java
+++ b/src/shared/test/java/com/couchbase/lite/LogTest.java
@@ -321,25 +321,26 @@ public class LogTest extends BaseTest {
         Log.d(LogDomain.DATABASE, "TEST DEBUG", new Exception("whoops"));
         assertEquals("TEST DEBUG (java.lang.Exception: whoops)", logger.getMessage());
 
-        Log.d(LogDomain.DATABASE, "TEST DEBUG %s %d %f", "arg", 1, 3.0F);
-        assertEquals("TEST DEBUG arg 1 3.000000", logger.getMessage());
+        // test formatting, including argument ordering
+        Log.d(LogDomain.DATABASE, "TEST DEBUG %2$s %1$d %3$.2f", 1, "arg", 3.0F);
+        assertEquals("TEST DEBUG arg 1 3.00", logger.getMessage());
 
-        Log.d(LogDomain.DATABASE, "TEST DEBUG %s %d %f", new Exception("whoops"), "arg", 1, 3.0F);
-        assertEquals("TEST DEBUG arg 1 3.000000 (java.lang.Exception: whoops)", logger.getMessage());
+        Log.d(LogDomain.DATABASE, "TEST DEBUG %2$s %1$d %3$.2f", new Exception("whoops"), 1, "arg", 3.0F);
+        assertEquals("TEST DEBUG arg 1 3.00 (java.lang.Exception: whoops)", logger.getMessage());
     }
 
     @Test
     public void testLogStandardErrorWithFormatting() {
         Map<String, String> stdErr = new HashMap<>();
-        stdErr.put("FOO", "TEST DEBUG arg 1 3.000000");
+        stdErr.put("FOO", "TEST DEBUG %2$s %1$d %3$.2f");
 
         Log.initLogging(stdErr);
 
         BasicLogger logger = new BasicLogger();
         Database.log.setCustom(logger);
 
-        Log.d(LogDomain.DATABASE, "FOO", new Exception("whoops"), "arg", 1, 3.0F);
-        assertEquals("TEST DEBUG arg 1 3.000000 (java.lang.Exception: whoops)", logger.getMessage());
+        Log.d(LogDomain.DATABASE, "FOO", new Exception("whoops"), 1, "arg", 3.0F);
+        assertEquals("TEST DEBUG arg 1 3.00 (java.lang.Exception: whoops)", logger.getMessage());
     }
 
     @Test


### PR DESCRIPTION
The standard error messages are now available.  Just need to find them and use them.