### PR TITLE
Add write with length for BlobStream

### DIFF
--- a/src/shared/main/cpp/native_c4blobstore.cc
+++ b/src/shared/main/cpp/native_c4blobstore.cc
@@ -307,21 +307,12 @@ Java_com_couchbase_lite_internal_core_C4BlobReadStream_close(JNIEnv *env, jclass
 /*
  * Class:     com_couchbase_lite_internal_core_C4BlobWriteStream
  * Method:    write
- * Signature: (J[B)V
- */
-JNIEXPORT void JNICALL Java_com_couchbase_lite_internal_core_C4BlobWriteStream_write__J_3B(JNIEnv * env, jclass clazz,
-                                                              jlong jstream, jbyteArray jbytes) {
-    Java_com_couchbase_lite_internal_core_C4BlobWriteStream_write__J_3BI(env, clazz, jstream, jbytes, 0);
-}
-
-/*
- * Class:     com_couchbase_lite_internal_core_C4BlobWriteStream
- * Method:    write
  * Signature: (J[BI)V
  */
-JNIEXPORT void JNICALL Java_com_couchbase_lite_internal_core_C4BlobWriteStream_write__J_3BI(JNIEnv * env, jclass clazz,
-                                                              jlong jstream, jbyteArray jbytes, jint len) {
-    int length = len;
+JNIEXPORT void JNICALL
+Java_com_couchbase_lite_internal_core_C4BlobWriteStream_write(JNIEnv * env, jclass clazz, jlong jstream,
+                                                  jbyteArray jbytes, jint jsize) {
+    int length = jsize;
     if (length < 0)
         length = 0;
 

--- a/src/shared/main/cpp/native_c4blobstore.cc
+++ b/src/shared/main/cpp/native_c4blobstore.cc
@@ -309,15 +309,27 @@ Java_com_couchbase_lite_internal_core_C4BlobReadStream_close(JNIEnv *env, jclass
  * Method:    write
  * Signature: (J[B)V
  */
-JNIEXPORT void JNICALL
-Java_com_couchbase_lite_internal_core_C4BlobWriteStream_write(JNIEnv *env, jclass clazz, jlong jstream,
-                                                    jbyteArray jbytes) {
-    jbyteArraySlice bytes(env, jbytes, true);
+JNIEXPORT void JNICALL Java_com_couchbase_lite_internal_core_C4BlobWriteStream_write__J_3B(JNIEnv * env, jclass clazz,
+                                                              jlong jstream, jbyteArray jbytes) {
+    Java_com_couchbase_lite_internal_core_C4BlobWriteStream_write__J_3BI(env, clazz, jstream, jbytes, 0);
+}
+
+/*
+ * Class:     com_couchbase_lite_internal_core_C4BlobWriteStream
+ * Method:    write
+ * Signature: (J[BI)V
+ */
+JNIEXPORT void JNICALL Java_com_couchbase_lite_internal_core_C4BlobWriteStream_write__J_3BI(JNIEnv * env, jclass clazz,
+                                                              jlong jstream, jbyteArray jbytes, jint len) {
+    int length = len;
+    if (length < 0)
+        length = 0;
+
+    jbyteArraySlice bytes(env, jbytes, (size_t) length, true);
     C4Slice slice = (C4Slice) bytes;
     C4Error error = {};
     if (!c4stream_write((C4WriteStream *) jstream, slice.buf, slice.size, &error))
         throwError(env, error);
-
 }
 
 /*

--- a/src/shared/main/cpp/native_c4blobstore.cc
+++ b/src/shared/main/cpp/native_c4blobstore.cc
@@ -312,11 +312,7 @@ Java_com_couchbase_lite_internal_core_C4BlobReadStream_close(JNIEnv *env, jclass
 JNIEXPORT void JNICALL
 Java_com_couchbase_lite_internal_core_C4BlobWriteStream_write(JNIEnv * env, jclass clazz, jlong jstream,
                                                   jbyteArray jbytes, jint jsize) {
-    int length = jsize;
-    if (length < 0)
-        length = 0;
-
-    jbyteArraySlice bytes(env, jbytes, (size_t) length, true);
+    jbyteArraySlice bytes(env, jbytes, (size_t) jsize, true);
     C4Slice slice = (C4Slice) bytes;
     C4Error error = {};
     if (!c4stream_write((C4WriteStream *) jstream, slice.buf, slice.size, &error))

--- a/src/shared/main/cpp/native_glue.cc
+++ b/src/shared/main/cpp/native_glue.cc
@@ -162,6 +162,8 @@ namespace litecore {
         // ATTN: In critical, should not call any other JNI methods.
         // http://docs.oracle.com/javase/6/docs/technotes/guides/jni/spec/functions.html
         jbyteArraySlice::jbyteArraySlice(JNIEnv *env, jbyteArray jbytes, bool critical)
+                : jbyteArraySlice(env, jbytes, 0, critical) { }
+        jbyteArraySlice::jbyteArraySlice(JNIEnv *env, jbyteArray jbytes, size_t length, bool critical)
                 : _env(env),
                   _jbytes(jbytes),
                   _critical(critical) {
@@ -176,7 +178,11 @@ namespace litecore {
             } else {
                 data = env->GetByteArrayElements(jbytes, NULL);
             }
-            _slice = { data, (size_t) env->GetArrayLength(jbytes) };
+
+            if (length <= 0)
+                length = (size_t) env->GetArrayLength(jbytes);
+
+            _slice = { data,  length };
         }
 
         jbyteArraySlice::~jbyteArraySlice() {

--- a/src/shared/main/cpp/native_glue.cc
+++ b/src/shared/main/cpp/native_glue.cc
@@ -161,11 +161,13 @@ namespace litecore {
 
         // ATTN: In critical, should not call any other JNI methods.
         // http://docs.oracle.com/javase/6/docs/technotes/guides/jni/spec/functions.html
+        jbyteArraySlice::jbyteArraySlice(JNIEnv *env, jbyteArray jbytes, bool critical)
+            : jbyteArraySlice(env, jbytes, (size_t) (!jbytes ? 0 : env->GetArrayLength(jbytes)), critical) { }
         jbyteArraySlice::jbyteArraySlice(JNIEnv *env, jbyteArray jbytes, size_t length, bool critical)
                 : _env(env),
                   _jbytes(jbytes),
                   _critical(critical) {
-            if (jbytes == nullptr) {
+            if (!jbytes || length <= 0) {
                 _slice = kFLSliceNull;
                 return;
             }
@@ -176,9 +178,6 @@ namespace litecore {
             } else {
                 data = env->GetByteArrayElements(jbytes, NULL);
             }
-
-            if (length <= 0)
-                length = (size_t) env->GetArrayLength(jbytes);
 
             _slice = { data, length };
         }

--- a/src/shared/main/cpp/native_glue.cc
+++ b/src/shared/main/cpp/native_glue.cc
@@ -161,8 +161,6 @@ namespace litecore {
 
         // ATTN: In critical, should not call any other JNI methods.
         // http://docs.oracle.com/javase/6/docs/technotes/guides/jni/spec/functions.html
-        jbyteArraySlice::jbyteArraySlice(JNIEnv *env, jbyteArray jbytes, bool critical)
-                : jbyteArraySlice(env, jbytes, 0, critical) { }
         jbyteArraySlice::jbyteArraySlice(JNIEnv *env, jbyteArray jbytes, size_t length, bool critical)
                 : _env(env),
                   _jbytes(jbytes),
@@ -182,7 +180,7 @@ namespace litecore {
             if (length <= 0)
                 length = (size_t) env->GetArrayLength(jbytes);
 
-            _slice = { data,  length };
+            _slice = { data, length };
         }
 
         jbyteArraySlice::~jbyteArraySlice() {

--- a/src/shared/main/cpp/native_glue.hh
+++ b/src/shared/main/cpp/native_glue.hh
@@ -65,6 +65,7 @@ namespace litecore {
             // Warning: If `critical` is true, you cannot make any further JNI calls (except other
             // critical accesses) until this object goes out of scope or is deleted.
             jbyteArraySlice(JNIEnv *env, jbyteArray jbytes, bool critical = false);
+            jbyteArraySlice(JNIEnv *env, jbyteArray jbytes, size_t length, bool critical = false);
 
             ~jbyteArraySlice();
 

--- a/src/shared/main/cpp/native_glue.hh
+++ b/src/shared/main/cpp/native_glue.hh
@@ -64,7 +64,8 @@ namespace litecore {
         public:
             // Warning: If `critical` is true, you cannot make any further JNI calls (except other
             // critical accesses) until this object goes out of scope or is deleted.
-            jbyteArraySlice(JNIEnv *env, jbyteArray jbytes, size_t length = 0, bool critical = false);
+            jbyteArraySlice(JNIEnv *env, jbyteArray jbytes, bool critical = false);
+            jbyteArraySlice(JNIEnv *env, jbyteArray jbytes, size_t length, bool critical = false);
 
             ~jbyteArraySlice();
 

--- a/src/shared/main/cpp/native_glue.hh
+++ b/src/shared/main/cpp/native_glue.hh
@@ -64,8 +64,7 @@ namespace litecore {
         public:
             // Warning: If `critical` is true, you cannot make any further JNI calls (except other
             // critical accesses) until this object goes out of scope or is deleted.
-            jbyteArraySlice(JNIEnv *env, jbyteArray jbytes, bool critical = false);
-            jbyteArraySlice(JNIEnv *env, jbyteArray jbytes, size_t length, bool critical = false);
+            jbyteArraySlice(JNIEnv *env, jbyteArray jbytes, size_t length = 0, bool critical = false);
 
             ~jbyteArraySlice();
 

--- a/src/shared/main/java/com/couchbase/lite/internal/core/C4BlobWriteStream.java
+++ b/src/shared/main/java/com/couchbase/lite/internal/core/C4BlobWriteStream.java
@@ -17,7 +17,10 @@
 //
 package com.couchbase.lite.internal.core;
 
+import android.support.annotation.NonNull;
+
 import com.couchbase.lite.LiteCoreException;
+import com.couchbase.lite.internal.utils.Preconditions;
 
 
 /**
@@ -54,14 +57,16 @@ public class C4BlobWriteStream {
     /**
      * Writes data to a stream.
      */
-    public void write(byte[] bytes) throws LiteCoreException {
-        write(handle, bytes, 0);
+    public void write(@NonNull byte[] bytes) throws LiteCoreException {
+        write(bytes, bytes.length);
     }
 
     /**
      * Writes data to a stream.
      */
-    public void write(byte[] bytes, int len) throws LiteCoreException {
+    public void write(@NonNull byte[] bytes, int len) throws LiteCoreException {
+        Preconditions.checkArgNotNull(bytes, "bytes");
+        if (len <= 0) { return; }
         write(handle, bytes, len);
     }
 

--- a/src/shared/main/java/com/couchbase/lite/internal/core/C4BlobWriteStream.java
+++ b/src/shared/main/java/com/couchbase/lite/internal/core/C4BlobWriteStream.java
@@ -29,6 +29,8 @@ public class C4BlobWriteStream {
     //-------------------------------------------------------------------------
     static native void write(long writeStream, byte[] bytes) throws LiteCoreException;
 
+    static native void write(long writeStream, byte[] bytes, int len) throws LiteCoreException;
+
     static native long computeBlobKey(long writeStream) throws LiteCoreException;
 
     //-------------------------------------------------------------------------
@@ -56,6 +58,13 @@ public class C4BlobWriteStream {
      */
     public void write(byte[] bytes) throws LiteCoreException {
         write(handle, bytes);
+    }
+
+    /**
+     * Writes data to a stream.
+     */
+    public void write(byte[] bytes, int len) throws LiteCoreException {
+        write(handle, bytes, len);
     }
 
     /**

--- a/src/shared/main/java/com/couchbase/lite/internal/core/C4BlobWriteStream.java
+++ b/src/shared/main/java/com/couchbase/lite/internal/core/C4BlobWriteStream.java
@@ -27,8 +27,6 @@ public class C4BlobWriteStream {
     //-------------------------------------------------------------------------
     // native methods
     //-------------------------------------------------------------------------
-    static native void write(long writeStream, byte[] bytes) throws LiteCoreException;
-
     static native void write(long writeStream, byte[] bytes, int len) throws LiteCoreException;
 
     static native long computeBlobKey(long writeStream) throws LiteCoreException;
@@ -57,7 +55,7 @@ public class C4BlobWriteStream {
      * Writes data to a stream.
      */
     public void write(byte[] bytes) throws LiteCoreException {
-        write(handle, bytes);
+        write(handle, bytes, 0);
     }
 
     /**


### PR DESCRIPTION
There is way too much copying of large arrays, when managing blobs.  This method should reduce the number of copies by one.