### PR TITLE
CBL-497: getLogLevel changes log level

### DIFF
--- a/lib/src/shared/main/java/com/couchbase/lite/AbstractDatabase.java
+++ b/lib/src/shared/main/java/com/couchbase/lite/AbstractDatabase.java
@@ -278,6 +278,9 @@ abstract class AbstractDatabase {
 
         // Initialize a shared keys:
         this.sharedKeys = new SharedKeys(c4db);
+
+        // warn if logging has not been turned on
+        Log.warn();
     }
 
     /**

--- a/lib/src/shared/main/java/com/couchbase/lite/internal/support/Log.java
+++ b/lib/src/shared/main/java/com/couchbase/lite/internal/support/Log.java
@@ -27,6 +27,7 @@ import java.util.HashMap;
 import java.util.IllegalFormatException;
 import java.util.Locale;
 import java.util.Map;
+import java.util.concurrent.atomic.AtomicBoolean;
 
 import com.couchbase.lite.ConsoleLogger;
 import com.couchbase.lite.Database;
@@ -43,6 +44,8 @@ import com.couchbase.lite.internal.core.CBLVersion;
  * Couchbase Lite Internal Log Utility.
  */
 public final class Log {
+    private static final AtomicBoolean WARNED = new AtomicBoolean(false);
+
     // Utility class.
     private Log() { }
 
@@ -347,6 +350,14 @@ public final class Log {
                     break;
             }
         }
+    }
+
+    public static void warn() {
+        if (WARNED.getAndSet(true)) { return; }
+        Log.w(
+            LogDomain.DATABASE,
+            "Database.log.getFile().getConfig() is now null: logging is disabled.  "
+                + "Log files required for product support are not being generated.");
     }
 
     private static void log(

--- a/lib/src/shared/test/java/com/couchbase/lite/BaseTest.java
+++ b/lib/src/shared/test/java/com/couchbase/lite/BaseTest.java
@@ -80,7 +80,7 @@ public class BaseTest extends PlatformBaseTest {
     public void setUp() throws CouchbaseLiteException {
         initCouchbaseLite();
 
-        Database.log.getConsole().setLevel(LogLevel.INFO);
+        Database.log.getConsole().setLevel(LogLevel.DEBUG);
         //setupFileLogging(); // if needed
 
         executor = CouchbaseLite.getExecutionService().getSerialExecutor();


### PR DESCRIPTION
Fix inconsistent log levels for bindings and core.  We trust the bindings.