### PR TITLE
Add thread diagnostics

### DIFF
--- a/lib/src/shared/main/java/com/couchbase/lite/AbstractReplicator.java
+++ b/lib/src/shared/main/java/com/couchbase/lite/AbstractReplicator.java
@@ -36,7 +36,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.Executor;
-import java.util.concurrent.RejectedExecutionException;
 
 import com.couchbase.lite.internal.CBLStatus;
 import com.couchbase.lite.internal.ExecutionService;
@@ -191,10 +190,7 @@ public abstract class AbstractReplicator extends NetworkReachabilityListener {
             final AbstractReplicator replicator = (AbstractReplicator) context;
             if (repl != replicator.c4repl) { return; }
 
-            try { dispatcher.execute(() -> replicator.c4StatusChanged(status)); }
-            catch (RejectedExecutionException e) {
-                throw new IllegalStateException("Execution rejected in status change notification: " + dispatcher, e);
-            }
+            dispatcher.execute(() -> replicator.c4StatusChanged(status));
         }
 
         @Override
@@ -209,10 +205,7 @@ public abstract class AbstractReplicator extends NetworkReachabilityListener {
             final AbstractReplicator replicator = (AbstractReplicator) context;
             if (repl != replicator.c4repl) { return; }
 
-            try { dispatcher.execute(() -> replicator.documentEnded(pushing, documents)); }
-            catch (RejectedExecutionException e) {
-                throw new IllegalStateException("Execution rejected document end notification: " + dispatcher, e);
-            }
+            dispatcher.execute(() -> replicator.documentEnded(pushing, documents));
         }
     }
 
@@ -663,12 +656,7 @@ public abstract class AbstractReplicator extends NetworkReachabilityListener {
 
         if ((pendingNotifications != null) && (pendingNotifications.size() > 0)) {
             for (C4ReplicatorStatus status : pendingNotifications) {
-                try { dispatcher.execute(() -> c4StatusChanged(status)); }
-                catch (RejectedExecutionException e) {
-                    throw new IllegalStateException(
-                        "Execution rejected delivering pending notifications: " + dispatcher,
-                        e);
-                }
+                dispatcher.execute(() -> c4StatusChanged(status));
             }
         }
     }

--- a/lib/src/shared/main/java/com/couchbase/lite/ReplicatorChangeListenerToken.java
+++ b/lib/src/shared/main/java/com/couchbase/lite/ReplicatorChangeListenerToken.java
@@ -32,7 +32,6 @@ final class ReplicatorChangeListenerToken implements ListenerToken {
 
     void notify(final ReplicatorChange change) { getExecutor().execute(() -> listener.changed(change)); }
 
-
     Executor getExecutor() {
         return (executor != null) ? executor : CouchbaseLite.getExecutionService().getMainExecutor();
     }
@@ -49,7 +48,6 @@ final class DocumentReplicationListenerToken implements ListenerToken {
     }
 
     void notify(final DocumentReplication update) { getExecutor().execute(() -> listener.replication(update)); }
-
 
     Executor getExecutor() {
         return (executor != null) ? executor : CouchbaseLite.getExecutionService().getMainExecutor();

--- a/lib/src/shared/main/java/com/couchbase/lite/internal/AbstractExecutionService.java
+++ b/lib/src/shared/main/java/com/couchbase/lite/internal/AbstractExecutionService.java
@@ -21,9 +21,17 @@ import android.support.annotation.NonNull;
 import android.support.annotation.VisibleForTesting;
 
 import java.util.ArrayDeque;
+import java.util.ArrayList;
+import java.util.Deque;
+import java.util.Map;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.Executor;
+import java.util.concurrent.RejectedExecutionException;
+import java.util.concurrent.ThreadPoolExecutor;
 import java.util.concurrent.TimeUnit;
+
+import com.couchbase.lite.LogDomain;
+import com.couchbase.lite.internal.support.Log;
 
 
 /**
@@ -31,6 +39,43 @@ import java.util.concurrent.TimeUnit;
  * executor.
  */
 public abstract class AbstractExecutionService implements ExecutionService {
+    private static final LogDomain DOMAIN = LogDomain.DATABASE;
+    private static final Object DUMP_LOCK = new Object();
+    private static long lastDump;
+
+    public static class InstrumentedTask implements Runnable {
+        private final Exception origin = null; // useful but extremely expensive: = new Exception();
+        private final Runnable task;
+        private final Runnable onComplete;
+
+        private final long createdAt = System.currentTimeMillis();
+        private long startedAt;
+        private long finishedAt;
+        private long completedAt;
+
+        public InstrumentedTask(Runnable task, Runnable onComplete) {
+            this.task = task;
+            this.onComplete = onComplete;
+        }
+
+        public void run() {
+            try {
+                startedAt = System.currentTimeMillis();
+                task.run();
+                finishedAt = System.currentTimeMillis();
+            }
+            finally {
+                onComplete.run();
+            }
+            completedAt = System.currentTimeMillis();
+        }
+
+        public String toString() {
+            return "task[" + createdAt + "," + startedAt + "," + finishedAt + "," + completedAt + " @" + task + "]";
+        }
+    }
+
+    // thin wrapper around the AsyncTask's THREAD_POOL_EXECUTOR
     private static class ConcurrentExecutor implements CloseableExecutor {
         private final Executor executor;
         private CountDownLatch stopLatch;
@@ -42,12 +87,14 @@ public abstract class AbstractExecutionService implements ExecutionService {
         public synchronized void execute(@NonNull Runnable task) {
             if (stopLatch != null) { throw new ExecutorClosedExeception("Executor has been stopped"); }
 
-            running++;
-
-            executor.execute(() -> {
-                try { task.run(); }
-                finally { finishTask(); }
-            });
+            try {
+                executor.execute(new InstrumentedTask(task, this::finishTask));
+                running++;
+            }
+            catch (RejectedExecutionException e) {
+                dumpServiceState(executor, e, "size: " + running);
+                throw e;
+            }
         }
 
         @Override
@@ -90,11 +137,13 @@ public abstract class AbstractExecutionService implements ExecutionService {
 
     // Patterned after AsyncTask's executor
     private static class SerialExecutor implements CloseableExecutor {
-        private final ArrayDeque<Runnable> tasks = new ArrayDeque<>();
+        private final Deque<InstrumentedTask> tasks = new ArrayDeque<>();
         private final Executor executor;
+
+        // If non-null, this executor has been stopped.
         private CountDownLatch stopLatch;
 
-        private Runnable running;
+        private InstrumentedTask running;
 
         private SerialExecutor(Executor executor) { this.executor = executor; }
 
@@ -102,10 +151,7 @@ public abstract class AbstractExecutionService implements ExecutionService {
         public synchronized void execute(@NonNull Runnable task) {
             if (stopLatch != null) { throw new ExecutorClosedExeception("Executor has been stopped"); }
 
-            tasks.offer(() -> {
-                try { task.run(); }
-                finally { scheduleNext(); }
-            });
+            tasks.offerLast(new InstrumentedTask(task, this::scheduleNext));
 
             if (running == null) { scheduleNext(); }
         }
@@ -113,16 +159,15 @@ public abstract class AbstractExecutionService implements ExecutionService {
         @Override
         public boolean stop(long timeout, @NonNull TimeUnit unit) {
             final CountDownLatch latch;
-            final int n;
             synchronized (this) {
-                n = (running == null) ? 0 : tasks.size() + 1;
-
-                if (stopLatch == null) { stopLatch = new CountDownLatch(n); }
-
-                if (n <= 0) { return true; }
+                if (stopLatch == null) {
+                    stopLatch = new CountDownLatch((running == null) ? 0 : tasks.size() + 1);
+                }
 
                 latch = stopLatch;
             }
+
+            if (latch.getCount() <= 0) { return true; }
 
             try { return latch.await(timeout, unit); }
             catch (InterruptedException ignore) { }
@@ -130,45 +175,100 @@ public abstract class AbstractExecutionService implements ExecutionService {
             return false;
         }
 
-        private synchronized void scheduleNext() {
-            if (stopLatch != null) { stopLatch.countDown(); }
+        private void scheduleNext() {
+            synchronized (this) {
+                if (stopLatch != null) { stopLatch.countDown(); }
 
-            running = tasks.poll();
+                final InstrumentedTask prev = running;
+                running = tasks.poll();
+                if (running == null) { return; }
 
-            if (running != null) { executor.execute(running); }
+                try { executor.execute(running); }
+                catch (RejectedExecutionException e) {
+                    dumpExecutorState(e, prev, running, tasks);
+                    running = null;
+                }
+            }
+        }
+
+        private void dumpExecutorState(
+            RejectedExecutionException ex,
+            InstrumentedTask prev,
+            InstrumentedTask current,
+            Deque<InstrumentedTask> tasks) {
+            if (throttle()) { return; }
+
+            dumpServiceState(executor, ex, "size: " + tasks.size());
+
+            Log.d(DOMAIN, "==== Serial Executor status: " + this);
+
+            if (prev != null) { Log.d(DOMAIN, "== Previous task: " + prev, prev.origin); }
+
+            if (current != null) { Log.d(DOMAIN, "== Current task: " + current, current.origin); }
+
+            final ArrayList<InstrumentedTask> waiting = new ArrayList<>(tasks);
+            Log.d(DOMAIN, "== Waiting tasks: " + waiting.size());
+            int n = 0;
+            for (InstrumentedTask t : waiting) { Log.d(DOMAIN, "@" + (++n) + ": " + t, t.origin); }
         }
     }
 
-    private final CloseableExecutor concurrentExecutor;
+    private final ThreadPoolExecutor baseExecutor;
+    private final ConcurrentExecutor concurrentExecutor;
 
-    public AbstractExecutionService() { concurrentExecutor = new ConcurrentExecutor(getThreadPoolExecutor()); }
-
-    @NonNull
-    public abstract Executor getThreadPoolExecutor();
-
-    @NonNull
-    public abstract Executor getMainExecutor();
-
-    @Override
-    public abstract Cancellable postDelayedOnExecutor(long delayMs, @NonNull Executor executor, @NonNull Runnable task);
-
-    @Override
-    public abstract void cancelDelayedTask(@NonNull Cancellable cancellableTask);
-
-    @NonNull
-    @Override
-    public CloseableExecutor getSerialExecutor() {
-        return new SerialExecutor(getThreadPoolExecutor());
+    public AbstractExecutionService(@NonNull ThreadPoolExecutor baseExecutor) {
+        this.baseExecutor = baseExecutor;
+        concurrentExecutor = new ConcurrentExecutor(baseExecutor);
     }
 
     @NonNull
     @Override
-    public CloseableExecutor getConcurrentExecutor() {
-        return concurrentExecutor;
-    }
+    public CloseableExecutor getSerialExecutor() { return new SerialExecutor(baseExecutor); }
+
+    @NonNull
+    @Override
+    public CloseableExecutor getConcurrentExecutor() { return concurrentExecutor; }
 
     @VisibleForTesting
-    void restartConcurrentExecutor() {
-        ((ConcurrentExecutor) concurrentExecutor).restart();
+    public ThreadPoolExecutor getBaseExecutor() { return baseExecutor; }
+
+    @VisibleForTesting
+    void restartConcurrentExecutor() { concurrentExecutor.restart(); }
+
+    static void dumpServiceState(Executor ex, Exception e, String msg) { dumpServiceState(ex, e, null, msg); }
+
+    private static void dumpServiceState(Executor ex, Exception e, Exception origin, String msg) {
+        if (throttle()) { return; }
+
+        Log.d(LogDomain.DATABASE, "!!!! Catastrophic failure on executor " + ex + ": " + msg, e);
+        if (origin != null) { Log.d(DOMAIN, "!! Origin: ", origin); }
+
+        final Map<Thread, StackTraceElement[]> stackTraces = Thread.getAllStackTraces();
+        Log.d(DOMAIN, "==== Threads: " + stackTraces.size());
+        for (Map.Entry<Thread, StackTraceElement[]> stack : stackTraces.entrySet()) {
+            Log.d(DOMAIN, "== Thread: " + stack.getKey());
+            for (StackTraceElement frame : stack.getValue()) { Log.d(DOMAIN, "      at " + frame); }
+        }
+
+        if (!(ex instanceof ThreadPoolExecutor)) { return; }
+
+        final ArrayList<Runnable> waiting = new ArrayList<>(((ThreadPoolExecutor) ex).getQueue());
+        Log.d(DOMAIN, "==== Executor queue: " + waiting.size());
+        int n = 0;
+        for (Runnable r : waiting) {
+            final Exception orig = (!(r instanceof InstrumentedTask)) ? null : ((InstrumentedTask) r).origin;
+            Log.d(DOMAIN, "@" + (n++) + ": " + r, orig);
+        }
+    }
+
+    private static boolean throttle() {
+        final long now = System.currentTimeMillis();
+        synchronized (DUMP_LOCK) {
+            // don't dump any more than once a second
+            if ((now - lastDump) < 1000) { return true; }
+            lastDump = now;
+        }
+        return false;
     }
 }
+

--- a/lib/src/shared/main/java/com/couchbase/lite/internal/AbstractExecutionService.java
+++ b/lib/src/shared/main/java/com/couchbase/lite/internal/AbstractExecutionService.java
@@ -196,7 +196,7 @@ public abstract class AbstractExecutionService implements ExecutionService {
             InstrumentedTask prev,
             InstrumentedTask current,
             Deque<InstrumentedTask> tasks) {
-            if (throttle()) { return; }
+            if (throttled()) { return; }
 
             dumpServiceState(executor, ex, "size: " + tasks.size());
 
@@ -238,7 +238,7 @@ public abstract class AbstractExecutionService implements ExecutionService {
     static void dumpServiceState(Executor ex, Exception e, String msg) { dumpServiceState(ex, e, null, msg); }
 
     private static void dumpServiceState(Executor ex, Exception e, Exception origin, String msg) {
-        if (throttle()) { return; }
+        if (throttled()) { return; }
 
         Log.d(LogDomain.DATABASE, "!!!! Catastrophic failure on executor " + ex + ": " + msg, e);
         if (origin != null) { Log.d(DOMAIN, "!! Origin: ", origin); }
@@ -261,7 +261,7 @@ public abstract class AbstractExecutionService implements ExecutionService {
         }
     }
 
-    private static boolean throttle() {
+    private static boolean throttled() {
         final long now = System.currentTimeMillis();
         synchronized (DUMP_LOCK) {
             // don't dump any more than once a second

--- a/lib/src/shared/main/java/com/couchbase/lite/internal/ExecutionService.java
+++ b/lib/src/shared/main/java/com/couchbase/lite/internal/ExecutionService.java
@@ -94,6 +94,7 @@ public interface ExecutionService {
      * @param task     the task to be executed.
      * @return a cancellable task
      */
+    @NonNull
     Cancellable postDelayedOnExecutor(long delayMs, @NonNull Executor executor, @NonNull Runnable task);
 
     /**

--- a/lib/src/shared/main/java/com/couchbase/lite/internal/support/Log.java
+++ b/lib/src/shared/main/java/com/couchbase/lite/internal/support/Log.java
@@ -103,7 +103,7 @@ public final class Log {
      * @param msg    The message you would like logged.
      * @param err    An exception to log
      */
-    public static void d(@NonNull LogDomain domain, @NonNull String msg, @NonNull Throwable err) {
+    public static void d(@NonNull LogDomain domain, @NonNull String msg, @Nullable Throwable err) {
         log(LogLevel.DEBUG, domain, err, msg);
     }
 
@@ -126,7 +126,7 @@ public final class Log {
      * @param err    An exception to log
      * @param args   Variable number of Object args to be used as params to formatString.
      */
-    public static void d(@NonNull LogDomain domain, @NonNull String msg, @NonNull Throwable err, Object... args) {
+    public static void d(@NonNull LogDomain domain, @NonNull String msg, @Nullable Throwable err, Object... args) {
         log(LogLevel.DEBUG, domain, err, msg, args);
     }
 
@@ -145,7 +145,7 @@ public final class Log {
      * @param msg    The message you would like logged.
      * @param err    An exception to log
      */
-    public static void v(@NonNull LogDomain domain, @NonNull String msg, @NonNull Throwable err) {
+    public static void v(@NonNull LogDomain domain, @NonNull String msg, @Nullable Throwable err) {
         log(LogLevel.VERBOSE, domain, err, msg);
     }
 
@@ -168,7 +168,7 @@ public final class Log {
      * @param err    An exception to log
      * @param args   Variable number of Object args to be used as params to formatString.
      */
-    public static void v(@NonNull LogDomain domain, @NonNull String msg, @NonNull Throwable err, Object... args) {
+    public static void v(@NonNull LogDomain domain, @NonNull String msg, @Nullable Throwable err, Object... args) {
         log(LogLevel.VERBOSE, domain, err, msg, args);
     }
 
@@ -189,11 +189,11 @@ public final class Log {
      * @param msg    The message you would like logged.
      * @param err    An exception to log
      */
-    public static void i(@NonNull LogDomain domain, @NonNull String msg, @NonNull Throwable err) {
+    public static void i(@NonNull LogDomain domain, @NonNull String msg, @Nullable Throwable err) {
         log(LogLevel.INFO, domain, err, msg);
     }
 
-    public static void info(@NonNull LogDomain domain, @NonNull String msg, @NonNull Throwable err) {
+    public static void info(@NonNull LogDomain domain, @NonNull String msg, @Nullable Throwable err) {
         i(domain, msg, err);
     }
 
@@ -216,7 +216,7 @@ public final class Log {
      * @param err    An exception to log
      * @param args   Variable number of Object args to be used as params to formatString.
      */
-    public static void i(@NonNull LogDomain domain, @NonNull String msg, @NonNull Throwable err, Object... args) {
+    public static void i(@NonNull LogDomain domain, @NonNull String msg, @Nullable Throwable err, Object... args) {
         log(LogLevel.INFO, domain, err, msg, args);
     }
 
@@ -235,7 +235,7 @@ public final class Log {
      * @param msg    The message you would like logged.
      * @param err    An exception to log
      */
-    public static void w(@NonNull LogDomain domain, @NonNull String msg, @NonNull Throwable err) {
+    public static void w(@NonNull LogDomain domain, @NonNull String msg, @Nullable Throwable err) {
         log(LogLevel.WARNING, domain, err, msg);
     }
 
@@ -258,7 +258,7 @@ public final class Log {
      * @param err    An exception to log
      * @param args   Variable number of Object args to be used as params to formatString.
      */
-    public static void w(@NonNull LogDomain domain, @NonNull String msg, @NonNull Throwable err, Object... args) {
+    public static void w(@NonNull LogDomain domain, @NonNull String msg, @Nullable Throwable err, Object... args) {
         log(LogLevel.WARNING, domain, err, msg, args);
     }
 
@@ -277,7 +277,7 @@ public final class Log {
      * @param msg    The message you would like logged.
      * @param err    An exception to log
      */
-    public static void e(@NonNull LogDomain domain, @NonNull String msg, @NonNull Throwable err) {
+    public static void e(@NonNull LogDomain domain, @NonNull String msg, @Nullable Throwable err) {
         log(LogLevel.ERROR, domain, err, msg);
     }
 
@@ -300,7 +300,7 @@ public final class Log {
      * @param err    An exception to log
      * @param args   Variable number of Object args to be used as params to formatString.
      */
-    public static void e(@NonNull LogDomain domain, @NonNull String msg, @NonNull Throwable err, Object... args) {
+    public static void e(@NonNull LogDomain domain, @NonNull String msg, @Nullable Throwable err, Object... args) {
         log(LogLevel.ERROR, domain, err, msg, args);
     }
 


### PR DESCRIPTION
This change adds task diagnostics to the CBL thread manager.  On catastrophic failures, it will log useful information helpful for identifying the cause of the failure