### PR TITLE
Make Java blobs work like .NET blobs

### DIFF
--- a/lib/src/shared/main/java/com/couchbase/lite/Blob.java
+++ b/lib/src/shared/main/java/com/couchbase/lite/Blob.java
@@ -333,7 +333,7 @@ public final class Blob implements FLEncodable {
      */
     @Nullable
     public byte[] getContent() {
-        // this will load blobContent from the blobContentStream
+        // this will load blobContent from the blobContentStream (all of it!)
         if (blobContentStream != null) { readContentFromInitStream(); }
 
         if (blobContent != null) { return copyBytes(blobContent); }
@@ -459,6 +459,17 @@ public final class Blob implements FLEncodable {
         return ((blobDigest != null) && (m.blobDigest != null))
             ? blobDigest.equals(m.blobDigest)
             : Arrays.equals(getContent(), m.getContent());
+    }
+
+    @SuppressWarnings("NoFinalizer")
+    @SuppressFBWarnings("DE_MIGHT_IGNORE")
+    @Override
+    protected void finalize() throws Throwable {
+        if (blobContentStream != null) {
+            try { blobContentStream.close(); }
+            catch (IOException ignore) { }
+        }
+        super.finalize();
     }
 
     //---------------------------------------------


### PR DESCRIPTION
My apologies, this is essentially another re-write.  I think you will do best simply to read the code, not the diffs.

All tests (android and java) pass.  ... and I think I've annoyed everyone with the details of this more-or-less unused feature, so that it implements something close to what iOS and .NET implement... warts and all.

Read the test code only if you are a masochist...