### PR TITLE
Feature/cbl 448

### DIFF
--- a/lib/src/shared/main/cpp/native_c4replicator.cc
+++ b/lib/src/shared/main/cpp/native_c4replicator.cc
@@ -271,8 +271,8 @@ static void statusChangedCallback(C4Replicator *repl, C4ReplicatorStatus status,
                                       m_C4Replicator_statusChangedCallback,
                                       (jlong) repl,
                                       toJavaObject(env, status));
-            if (gJVM->DetachCurrentThread() != 0) C4Warn(
-                    "doRequestClose(): Failed to detach the current thread from a Java VM");
+            if (gJVM->DetachCurrentThread() != 0)
+                C4Warn("doRequestClose(): Failed to detach the current thread from a Java VM");
         } else {
             C4Warn("doRequestClose(): Failed to attaches the current thread to a Java VM");
         }
@@ -310,8 +310,8 @@ static void documentEndedCallback(C4Replicator *repl,
                                       (jlong) repl,
                                       pushing,
                                       toJavaDocumentEndedArray(env, numDocs, documentEnded));
-            if (gJVM->DetachCurrentThread() != 0) C4Warn(
-                    "doRequestClose(): Failed to detach the current thread from a Java VM");
+            if (gJVM->DetachCurrentThread() != 0)
+                C4Warn("doRequestClose(): Failed to detach the current thread from a Java VM");
         } else {
             C4Warn("doRequestClose(): Failed to attaches the current thread to a Java VM");
         }
@@ -341,8 +341,8 @@ static jboolean replicationFilter(C4String docID, C4RevisionFlags flags, FLDict 
                                                (jlong) dict,
                                                isPush,
                                                (jobject) ctx);
-            if (gJVM->DetachCurrentThread() != 0) C4Warn(
-                    "doRequestClose(): Failed to detach the current thread from a Java VM");
+            if (gJVM->DetachCurrentThread() != 0)
+                C4Warn("doRequestClose(): Failed to detach the current thread from a Java VM");
         } else {
             C4Warn("doRequestClose(): Failed to attaches the current thread to a Java VM");
         }
@@ -561,7 +561,7 @@ Java_com_couchbase_lite_internal_core_C4Replicator_getPendingDocIds
     if (c4Error.domain != 0 && c4Error.code != 0)
         throwError(env, c4Error);
 
-    C4SliceResult *sliceResult = (C4SliceResult *) ::malloc(sizeof(C4SliceResult));
+    auto *sliceResult = (C4SliceResult *) ::malloc(sizeof(C4SliceResult));
 
     sliceResult->buf = res.buf;
     sliceResult->size = res.size;

--- a/lib/src/shared/main/cpp/native_c4replicator.cc
+++ b/lib/src/shared/main/cpp/native_c4replicator.cc
@@ -271,8 +271,8 @@ static void statusChangedCallback(C4Replicator *repl, C4ReplicatorStatus status,
                                       m_C4Replicator_statusChangedCallback,
                                       (jlong) repl,
                                       toJavaObject(env, status));
-            if (gJVM->DetachCurrentThread() != 0)
-                C4Warn("doRequestClose(): Failed to detach the current thread from a Java VM");
+            if (gJVM->DetachCurrentThread() != 0) C4Warn(
+                    "doRequestClose(): Failed to detach the current thread from a Java VM");
         } else {
             C4Warn("doRequestClose(): Failed to attaches the current thread to a Java VM");
         }
@@ -304,14 +304,14 @@ static void documentEndedCallback(C4Replicator *repl,
                                   pushing,
                                   toJavaDocumentEndedArray(env, numDocs, documentEnded));
     } else if (getEnvStat == JNI_EDETACHED) {
-        if (attachCurrentThread(&env)== 0) {
+        if (attachCurrentThread(&env) == 0) {
             env->CallStaticVoidMethod(cls_C4Replicator,
                                       m_C4Replicator_documentEndedCallback,
                                       (jlong) repl,
                                       pushing,
                                       toJavaDocumentEndedArray(env, numDocs, documentEnded));
-            if (gJVM->DetachCurrentThread() != 0)
-                C4Warn("doRequestClose(): Failed to detach the current thread from a Java VM");
+            if (gJVM->DetachCurrentThread() != 0) C4Warn(
+                    "doRequestClose(): Failed to detach the current thread from a Java VM");
         } else {
             C4Warn("doRequestClose(): Failed to attaches the current thread to a Java VM");
         }
@@ -341,8 +341,8 @@ static jboolean replicationFilter(C4String docID, C4RevisionFlags flags, FLDict 
                                                (jlong) dict,
                                                isPush,
                                                (jobject) ctx);
-            if (gJVM->DetachCurrentThread() != 0)
-                C4Warn("doRequestClose(): Failed to detach the current thread from a Java VM");
+            if (gJVM->DetachCurrentThread() != 0) C4Warn(
+                    "doRequestClose(): Failed to detach the current thread from a Java VM");
         } else {
             C4Warn("doRequestClose(): Failed to attaches the current thread to a Java VM");
         }
@@ -548,6 +548,49 @@ Java_com_couchbase_lite_internal_core_C4Replicator_getResponseHeaders(JNIEnv *en
 
 /*
  * Class:     com_couchbase_lite_internal_core_C4Replicator
+ * Method:    getPendingDocIDs
+ * Signature: (J)Ljava/lang/Object;
+ */
+JNIEXPORT jlong JNICALL
+Java_com_couchbase_lite_internal_core_C4Replicator_getPendingDocIds
+        (JNIEnv *env, jclass clazz, jlong repl) {
+    C4Error c4Error = {};
+
+    C4SliceResult res = c4repl_getPendingDocIDs((C4Replicator *) repl, &c4Error);
+
+    if (c4Error.domain != 0 && c4Error.code != 0)
+        throwError(env, c4Error);
+
+    C4SliceResult *sliceResult = (C4SliceResult *) ::malloc(sizeof(C4SliceResult));
+
+    sliceResult->buf = res.buf;
+    sliceResult->size = res.size;
+
+    return (jlong) sliceResult;
+}
+
+/*
+ * Class:     com_couchbase_lite_internal_core_C4Replicator
+ * Method:    isDocumentPending
+ * Signature: (JLjava/lang/String;)Z
+ */
+JNIEXPORT jboolean JNICALL
+Java_com_couchbase_lite_internal_core_C4Replicator_isDocumentPending
+        (JNIEnv *env, jclass clazz, jlong repl, jstring jDocId) {
+
+    jstringSlice docId(env, jDocId);
+
+    C4Error c4Error = {};
+    bool pending = c4repl_isDocumentPending((C4Replicator *) repl, docId, &c4Error);
+
+    if (c4Error.domain != 0 && c4Error.code != 0)
+        throwError(env, c4Error);
+
+    return (jboolean) pending;
+}
+
+/*
+ * Class:     com_couchbase_lite_internal_core_C4Replicator
  * Method:    mayBeTransient
  * Signature: (III)Z
  */
@@ -557,7 +600,7 @@ Java_com_couchbase_lite_internal_core_C4Replicator_mayBeTransient(JNIEnv *env,
                                                                   jint domain,
                                                                   jint code,
                                                                   jint ii) {
-    C4Error c4Error = { (C4ErrorDomain) domain, code, ii };
+    C4Error c4Error = {(C4ErrorDomain) domain, code, ii};
     return c4error_mayBeTransient(c4Error);
 }
 
@@ -572,7 +615,7 @@ Java_com_couchbase_lite_internal_core_C4Replicator_mayBeNetworkDependent(JNIEnv 
                                                                          jint domain,
                                                                          jint code,
                                                                          jint ii) {
-    C4Error c4Error = { (C4ErrorDomain) domain, code, ii };
+    C4Error c4Error = {(C4ErrorDomain) domain, code, ii};
     return c4error_mayBeNetworkDependent(c4Error);
 }
 

--- a/lib/src/shared/main/java/com/couchbase/lite/AbstractDatabase.java
+++ b/lib/src/shared/main/java/com/couchbase/lite/AbstractDatabase.java
@@ -1216,14 +1216,15 @@ abstract class AbstractDatabase {
         }
 
         Document resolvedDoc = null;
-        if (localDoc.isDeleted() && remoteDoc.isDeleted()) {
-            // Resolve automatically with the remote doc:
-            resolvedDoc = remoteDoc;
-        }
+        // If both docs have been deleted, we're done here
+        if (localDoc.isDeleted() && remoteDoc.isDeleted()) { resolvedDoc = remoteDoc; }
         else {
             // Resolve with conflict resolver:
-            resolvedDoc = resolveConflict((resolver != null) ?
-                resolver : ConflictResolver.DEFAULT, docID, localDoc, remoteDoc);
+            resolvedDoc = resolveConflict(
+                (resolver != null) ? resolver : ConflictResolver.DEFAULT,
+                docID,
+                localDoc,
+                remoteDoc);
         }
 
         synchronized (lock) {

--- a/lib/src/shared/main/java/com/couchbase/lite/AbstractReplicator.java
+++ b/lib/src/shared/main/java/com/couchbase/lite/AbstractReplicator.java
@@ -284,6 +284,7 @@ public abstract class AbstractReplicator extends NetworkReachabilityListener {
     // member variables
     //---------------------------------------------
 
+    @NonNull
     final ReplicatorConfiguration config;
 
     private final Object lock = new Object();
@@ -389,6 +390,60 @@ public abstract class AbstractReplicator extends NetworkReachabilityListener {
      */
     @NonNull
     public Status getStatus() { return status.copy(); }
+
+    @NonNull
+    public Set<String> getPendingDocumentIds() throws CouchbaseLiteException {
+        if (config.getReplicatorType().equals(ReplicatorConfiguration.ReplicatorType.PULL)) {
+            throw new CouchbaseLiteException(
+                "Pending Document IDs are not supported on pull-only replicators.",
+                Log.LOGGING_DOMAINS_TO_C4.get(DOMAIN),
+                CBLError.Code.UNSUPPORTED);
+        }
+
+        final C4Replicator repl;
+        synchronized (lock) { repl = c4repl; }
+
+        if (repl == null) {
+            Log.i(DOMAIN, "%s: Call to getPendingDocumentIds with unstarted replicator", this);
+            return Collections.emptySet();
+        }
+
+        final Set<String> pending;
+        try { pending = c4repl.getPendingDocIDs(); }
+        catch (LiteCoreException e) {
+            Log.w(DOMAIN, "Error while fetching pending documentIds: %d/%d", e.domain, e.code);
+            return Collections.emptySet();
+        }
+
+        return (pending.size() <= 0) ? Collections.emptySet() : Collections.unmodifiableSet(pending);
+    }
+
+    @NonNull
+    public boolean isDocumentPending(@NonNull String docId) throws CouchbaseLiteException {
+        Preconditions.checkArgNotNull(docId, "document ID");
+
+        if (config.getReplicatorType().equals(ReplicatorConfiguration.ReplicatorType.PULL)) {
+            throw new CouchbaseLiteException(
+                "Pending Document IDs are not supported on pull-only replicators.",
+                Log.LOGGING_DOMAINS_TO_C4.get(DOMAIN),
+                CBLError.Code.UNSUPPORTED);
+        }
+
+        final C4Replicator repl;
+        synchronized (lock) { repl = c4repl; }
+
+        if (repl == null) {
+            Log.i(DOMAIN, "%s: Call to isDocumentPending with unstarted replicator", this);
+            return false;
+        }
+
+        try { return c4repl.isDocumentPending(docId); }
+        catch (LiteCoreException e) {
+            Log.w(DOMAIN, "Error while fetching pending documentIds: %d/%d", e.domain, e.code);
+        }
+
+        return false;
+    }
 
     /**
      * Set the given ReplicatorChangeListener for this replicator, delivering events on the default executor
@@ -783,7 +838,7 @@ public abstract class AbstractReplicator extends NetworkReachabilityListener {
             status = c4repl.getStatus();
         }
         catch (LiteCoreException e) {
-            status = new C4ReplicatorStatus(C4ReplicatorStatus.ActivityLevel.STOPPED, e.domain, e.code );
+            status = new C4ReplicatorStatus(C4ReplicatorStatus.ActivityLevel.STOPPED, e.domain, e.code);
         }
 
         updateStateProperties((status != null)

--- a/lib/src/shared/main/java/com/couchbase/lite/AbstractReplicator.java
+++ b/lib/src/shared/main/java/com/couchbase/lite/AbstractReplicator.java
@@ -403,6 +403,7 @@ public abstract class AbstractReplicator extends NetworkReachabilityListener {
         final C4Replicator repl;
         synchronized (lock) { repl = c4repl; }
 
+        // !!! Need to return a result here: will require recreating the replicator.
         if (repl == null) {
             Log.i(DOMAIN, "%s: Call to getPendingDocumentIds with unstarted replicator", this);
             return Collections.emptySet();
@@ -410,10 +411,7 @@ public abstract class AbstractReplicator extends NetworkReachabilityListener {
 
         final Set<String> pending;
         try { pending = c4repl.getPendingDocIDs(); }
-        catch (LiteCoreException e) {
-            Log.w(DOMAIN, "Error while fetching pending documentIds: %d/%d", e.domain, e.code);
-            return Collections.emptySet();
-        }
+        catch (LiteCoreException e) { throw CBLStatus.convertException(e, "Failed fetching pending documentIds"); }
 
         return (pending.size() <= 0) ? Collections.emptySet() : Collections.unmodifiableSet(pending);
     }
@@ -432,17 +430,14 @@ public abstract class AbstractReplicator extends NetworkReachabilityListener {
         final C4Replicator repl;
         synchronized (lock) { repl = c4repl; }
 
+        // !!! Need to return a result here: will require recreating the replicator.
         if (repl == null) {
             Log.i(DOMAIN, "%s: Call to isDocumentPending with unstarted replicator", this);
             return false;
         }
 
         try { return c4repl.isDocumentPending(docId); }
-        catch (LiteCoreException e) {
-            Log.w(DOMAIN, "Error while fetching pending documentIds: %d/%d", e.domain, e.code);
-        }
-
-        return false;
+        catch (LiteCoreException e) { throw CBLStatus.convertException(e, "Failed getting document pending status"); }
     }
 
     /**

--- a/lib/src/shared/main/java/com/couchbase/lite/internal/CBLStatus.java
+++ b/lib/src/shared/main/java/com/couchbase/lite/internal/CBLStatus.java
@@ -36,6 +36,10 @@ public class CBLStatus {
         return convertException(e.domain, e.code, null, e);
     }
 
+    public static CouchbaseLiteException convertException(LiteCoreException e, String msg) {
+        return convertException(e.domain, e.code, msg, e);
+    }
+
     public static CouchbaseLiteException convertException(int domainCode, int statusCode, int internalInfo) {
         return ((domainCode == 0) || (statusCode == 0))
             ? convertException(domainCode, statusCode, null, null)

--- a/lib/src/shared/main/java/com/couchbase/lite/internal/core/C4Replicator.java
+++ b/lib/src/shared/main/java/com/couchbase/lite/internal/core/C4Replicator.java
@@ -24,10 +24,12 @@ import android.support.annotation.Nullable;
 
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Set;
 import java.util.concurrent.atomic.AtomicBoolean;
 
 import com.couchbase.lite.LiteCoreException;
 import com.couchbase.lite.LogDomain;
+import com.couchbase.lite.internal.fleece.FLSliceResult;
 import com.couchbase.lite.internal.support.Log;
 
 
@@ -247,6 +249,22 @@ public class C4Replicator {
         }
     }
 
+    public Set<String> getPendingDocIDs() throws LiteCoreException {
+        synchronized (lock) {
+            if (handle == 0) { return null; }
+
+            FLSliceResult result = new FLSliceResult(getPendingDocIds(handle));
+
+            return null;
+        }
+    }
+
+    public boolean isDocumentPending(String docId) throws LiteCoreException {
+        synchronized (lock) {
+            return (handle != 0) && isDocumentPending(handle, docId);
+        }
+    }
+
     @Nullable
     public byte[] getResponseHeaders() {
         synchronized (lock) {
@@ -352,6 +370,16 @@ public class C4Replicator {
     private static native byte[] getResponseHeaders(long replicator);
 
     /**
+     * Returns a list of string ids for pending documents.
+     */
+    private static native long getPendingDocIds(long handle) throws LiteCoreException;
+
+    /**
+     * Returns true if there are documents that have not been resolved.
+     */
+    private static native boolean isDocumentPending(long handle, String id) throws LiteCoreException;
+
+    /**
      * Returns true if this is a network error that may be transient,
      * i.e. the client should retry after a delay.
      */
@@ -363,3 +391,4 @@ public class C4Replicator {
      */
     private static native boolean mayBeNetworkDependent(int domain, int code, int info);
 }
+

--- a/lib/src/shared/main/java/com/couchbase/lite/internal/core/C4Replicator.java
+++ b/lib/src/shared/main/java/com/couchbase/lite/internal/core/C4Replicator.java
@@ -22,7 +22,9 @@ import android.support.annotation.GuardedBy;
 import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
 
+import java.util.Collections;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.atomic.AtomicBoolean;
@@ -30,6 +32,7 @@ import java.util.concurrent.atomic.AtomicBoolean;
 import com.couchbase.lite.LiteCoreException;
 import com.couchbase.lite.LogDomain;
 import com.couchbase.lite.internal.fleece.FLSliceResult;
+import com.couchbase.lite.internal.fleece.FLValue;
 import com.couchbase.lite.internal.support.Log;
 
 
@@ -253,9 +256,12 @@ public class C4Replicator {
         synchronized (lock) {
             if (handle == 0) { return null; }
 
-            FLSliceResult result = new FLSliceResult(getPendingDocIds(handle));
-
-            return null;
+            final FLSliceResult result = new FLSliceResult(getPendingDocIds(handle));
+            try {
+                final FLValue slice = FLValue.fromData(result);
+                return (slice == null) ? Collections.emptySet() : new HashSet<>(slice.asTypedArray());
+            }
+            finally { result.free(); }
         }
     }
 

--- a/lib/src/shared/main/java/com/couchbase/lite/internal/fleece/FLArray.java
+++ b/lib/src/shared/main/java/com/couchbase/lite/internal/fleece/FLArray.java
@@ -48,14 +48,17 @@ public class FLArray {
         this.handle = handle;
     }
 
-    public List<Object> asArray() {
-        final List<Object> results = new ArrayList<>();
+    public List<Object> asArray() { return asTypedArray(); }
+
+    @SuppressWarnings("unchecked")
+    public <T> List<T> asTypedArray() {
+        final List<T> results = new ArrayList<>();
         final FLArrayIterator itr = new FLArrayIterator();
         try {
             itr.begin(this);
             FLValue value;
             while ((value = itr.getValue()) != null) {
-                results.add(value.asObject());
+                results.add((T) value.asObject());
                 if (!itr.next()) { break; }
             }
         }

--- a/lib/src/shared/main/java/com/couchbase/lite/internal/fleece/FLValue.java
+++ b/lib/src/shared/main/java/com/couchbase/lite/internal/fleece/FLValue.java
@@ -17,6 +17,9 @@
 //
 package com.couchbase.lite.internal.fleece;
 
+import android.support.annotation.NonNull;
+import android.support.annotation.Nullable;
+
 import java.util.List;
 import java.util.Map;
 
@@ -29,23 +32,35 @@ public class FLValue {
     // public static methods
     //-------------------------------------------------------------------------
 
+    @Nullable
     public static FLValue fromData(AllocSlice slice) {
         if (slice == null) { return null; }
         final long value = fromData(slice.getHandle());
-        return value != 0 ? new FLValue(value) : null;
+        return value == 0 ? null : new FLValue(value);
     }
 
+    /**
+     * Converts valid JSON5 to JSON.
+     *
+     * @param json5 String
+     * @return JSON String
+     * @throws LiteCoreException on parse failure
+     */
+    @Nullable
+    public static String json5ToJson(String json5) throws LiteCoreException { return JSON5ToJSON(json5); }
+
+    @NonNull
     public static FLValue fromData(byte[] data) { return new FLValue(fromTrustedData(data)); }
 
+    @Nullable
     public static Object toObject(FLValue flValue) { return flValue.asObject(); }
 
-    public static String json5ToJson(String json5) throws LiteCoreException { return JSON5ToJSON(json5); }
 
     //-------------------------------------------------------------------------
     // Member Variables
     //-------------------------------------------------------------------------
 
-    private long handle; // pointer to FLValue
+    private final long handle; // pointer to FLValue
 
     //-------------------------------------------------------------------------
     // Constructor
@@ -60,49 +75,148 @@ public class FLValue {
     // public methods
     //-------------------------------------------------------------------------
 
+    /**
+     * Returns the data type of an arbitrary Value.
+     *
+     * @return int (FLValueType)
+     */
     public int getType() { return getType(handle); }
 
+    /**
+     * Is this value a number?
+     *
+     * @return true if value is a number
+     */
     public boolean isNumber() { return getType() == FLConstants.ValueType.NUMBER; }
 
+    /**
+     * Is this value an integer?
+     *
+     * @return true if value is a number
+     */
     public boolean isInteger() { return isInteger(handle); }
 
-    public boolean isDouble() { return isDouble(handle); }
-
+    /**
+     * Returns true if the value is non-nullptr and represents an _unsigned_ integer that can only
+     * be represented natively as a `uint64_t`.
+     *
+     * @return boolean
+     */
     public boolean isUnsigned() { return isUnsigned(handle); }
 
+    /**
+     * Is this a 64-bit floating-point value?
+     *
+     * @return true if value is a double
+     */
+    public boolean isDouble() { return isDouble(handle); }
+
+    /**
+     * Returns the string representation.
+     *
+     * @return string rep
+     */
     public String toStr() { return toString(handle); }
 
+    /**
+     * Returns the json representation.
+     *
+     * @return json rep
+     */
     public String toJSON() { return toJSON(handle); }
 
+    /**
+     * Returns the string representation.
+     *
+     * @return json5 rep
+     */
     public String toJSON5() { return toJSON5(handle); }
 
-    public boolean asBool() { return asBool(handle); }
-
-    public long asUnsigned() { return asUnsigned(handle); }
-
-    public long asInt() { return asInt(handle); }
-
+    /**
+     * Returns the exact contents of a data value, or null for all other types.
+     *
+     * @return byte[]
+     */
     public byte[] asData() { return asData(handle); }
 
+    /**
+     * Returns a value coerced to boolean.
+     *
+     * @return boolean
+     */
+    public boolean asBool() { return asBool(handle); }
+
+    /**
+     * Returns a value coerced to an integer.
+     * NOTE: litecore treats integer with 2^64. So this JNI method returns long value
+     *
+     * @return long
+     */
+    public long asInt() { return asInt(handle); }
+
+    /**
+     * Returns a value coerced to an unsigned integer.
+     *
+     * @return long
+     */
+    public long asUnsigned() { return asUnsigned(handle); }
+
+    /**
+     * Returns a value coerced to a 32-bit floating point number.
+     *
+     * @return float
+     */
     public float asFloat() { return asFloat(handle); }
 
+    /**
+     * Returns a value coerced to a 64-bit floating point number.
+     *
+     * @return double
+     */
     public double asDouble() { return asDouble(handle); }
 
-    // ??? If we are out of memory or the string cannot be decoded, we just lose it
+    /**
+     * Returns the exact contents of a string value, or null for all other types.
+     * ??? If we are out of memory or the string cannot be decoded, we just lose it
+     *
+     * @return String
+     */
     public String asString() {
         try { return asString(handle); }
         catch (LiteCoreException ignore) {}
         return null;
     }
 
-    public FLDict asFLDict() { return new FLDict(asDict(handle)); }
-
+    /**
+     * If a FLValue represents an array, returns it cast to FLArray, else nullptr.
+     *
+     * @return long (FLArray)
+     */
     public FLArray asFLArray() { return new FLArray(asArray(handle)); }
-
-    public Map<String, Object> asDict() { return asFLDict().asDict(); }
 
     public List<Object> asArray() { return asFLArray().asArray(); }
 
+    public <T> List<T> asTypedArray() { return asFLArray().asTypedArray(); }
+
+    /**
+     * Returns the contents as a dictionary.
+     *
+     * @return String
+     */
+    public FLDict asFLDict() { return new FLDict(asDict(handle)); }
+
+    /**
+     * If a FLValue represents an array, returns it cast to FLDict, else nullptr.
+     *
+     * @return long (FLDict)
+     */
+    public Map<String, Object> asDict() { return asFLDict().asDict(); }
+
+    /**
+     * Return an object of the appropriate type.
+     *
+     * @return Object
+     */
     public Object asObject() {
         switch (getType(handle)) {
             case FLConstants.ValueType.NULL:
@@ -141,130 +255,43 @@ public class FLValue {
      * @param data FLSlice (same with slice)
      * @return long (FLValue - const struct _FLValue*)
      */
-    static native long fromTrustedData(byte[] data);
+    private static native long fromTrustedData(byte[] data);
 
-    /**
-     * Returns the data type of an arbitrary Value.
-     *
-     * @param value FLValue
-     * @return int (FLValueType)
-     */
-    static native int getType(long value);
+    private static native long fromData(long slice);
 
-    /**
-     * Is this value an integer?
-     *
-     * @param value FLValue
-     * @return boolean
-     */
-    static native boolean isInteger(long value);
+    private static native int getType(long value);
 
-    /**
-     * Is this a 64-bit floating-point value?
-     *
-     * @param value FLValue
-     * @return boolean
-     */
-    static native boolean isDouble(long value);
+    private static native boolean isInteger(long value);
 
-    /**
-     * Returns true if the value is non-nullptr and represents an _unsigned_ integer that can only
-     * be represented natively as a `uint64_t`.
-     *
-     * @param value FLValue
-     * @return boolean
-     */
-    static native boolean isUnsigned(long value);
+    private static native boolean isUnsigned(long value);
 
-    /**
-     * Returns a value coerced to boolean.
-     *
-     * @param value FLValue
-     * @return boolean
-     */
-    static native boolean asBool(long value);
+    private static native boolean isDouble(long value);
 
-    /**
-     * Returns a value coerced to an unsigned integer.
-     *
-     * @param value FLValue
-     * @return long
-     */
-    static native long asUnsigned(long value);
+    private static native String toString(long handle);
 
-    /**
-     * Returns a value coerced to an integer.
-     * NOTE: litecore treats integer with 2^64. So this JNI method returns long value
-     *
-     * @param value FLValue
-     * @return long
-     */
-    static native long asInt(long value);
+    private static native String toJSON(long handle);
 
-    /**
-     * Returns a value coerced to a 32-bit floating point number.
-     *
-     * @param value FLValue
-     * @return float
-     */
-    static native float asFloat(long value);
+    private static native String toJSON5(long handle);
 
-    /**
-     * Returns a value coerced to a 64-bit floating point number.
-     *
-     * @param value FLValue
-     * @return double
-     */
-    static native double asDouble(long value);
+    private static native byte[] asData(long value);
 
-    /**
-     * Returns the exact contents of a string value, or null for all other types.
-     *
-     * @param value FLValue
-     * @return String
-     */
-    static native String asString(long value) throws LiteCoreException;
+    private static native boolean asBool(long value);
 
-    /**
-     * Returns the exact contents of a data value, or null for all other types.
-     *
-     * @param value FLValue
-     * @return byte[]
-     */
-    static native byte[] asData(long value);
+    private static native long asUnsigned(long value);
 
-    /**
-     * If a FLValue represents an array, returns it cast to FLArray, else nullptr.
-     *
-     * @param value FLValue
-     * @return long (FLArray)
-     */
-    static native long asArray(long value);
+    private static native long asInt(long value);
 
-    /**
-     * If a FLValue represents an array, returns it cast to FLDict, else nullptr.
-     *
-     * @param value FLValue
-     * @return long (FLDict)
-     */
-    static native long asDict(long value);
+    private static native float asFloat(long value);
 
-    /**
-     * Converts valid JSON5 to JSON.
-     *
-     * @param json5 String
-     * @return JSON String
-     * @throws LiteCoreException
-     */
+    private static native double asDouble(long value);
+
+    private static native String asString(long value) throws LiteCoreException;
+
+    private static native long asArray(long value);
+
+    private static native long asDict(long value);
+
     @SuppressWarnings({"MethodName", "PMD.MethodNamingConventions"})
-    static native String JSON5ToJSON(String json5) throws LiteCoreException;
-
-    static native long fromData(long slice);
-
-    static native String toString(long handle);
-
-    static native String toJSON(long handle);
-
-    static native String toJSON5(long handle);
+    private static native String JSON5ToJSON(String json5) throws LiteCoreException;
 }
 


### PR DESCRIPTION
Java-side code for CBL-448

Probably want to wait until "Make Java blobs work like .NET" is commited, before reading this.  This PR contains both.

The type (`jobject`) returned by the native call to `getPendingDocIDs` is, of course, a place-holder.  I'll replace it with the real type when I figure it out.