### PR TITLE
Fix windows build when using Visual Studio 2015

### DIFF
--- a/etc/jenkins/build_windows.bat
+++ b/etc/jenkins/build_windows.bat
@@ -27,7 +27,7 @@ echo ======== Building mbedcrypto ...
 call %cblJavaDir%\scripts\build_litecore.bat %vsGen% %edition% mbedcrypto
 
 echo ======== Build Couchbase Lite Java ...
-call gradlew.bat ciCheck -PbuildNumber=%buildNumber%
+call gradlew.bat ciCheckWindows -PbuildNumber=%buildNumber%
 
 echo ======== Create distribution zip for Couchbase Lite Java, %edition% Edition, Build %buildNumber%
 call gradlew.bat distZip -PbuildNumber=%buildNumber%

--- a/lib/build.gradle
+++ b/lib/build.gradle
@@ -255,6 +255,7 @@ model {
                 } else if (targetPlatform.operatingSystem.windows) {
                     cppCompiler.args "-I${JAVA_HOME}/include"
                     cppCompiler.args "-I${JAVA_HOME}/include/win32"
+                    cppCompiler.args "/MD"
                 }
             }
         }
@@ -480,6 +481,7 @@ task unitTest(dependsOn: ['smokeTest', 'test'])
 task fullTest(dependsOn: ['unitTest'])
 
 task ciCheck(dependsOn: ['checkstyle', 'pmd', 'findbugsXml', 'test'])
+task ciCheckWindows(dependsOn: ['pmd', 'findbugsXml', 'test'])
 task ciPublish(dependsOn: ['generatePomFileForMavenJavaPublication', 'publishMavenJavaPublicationToMavenRepository'])
 
 // ordering (roughly last to first)


### PR DESCRIPTION
* Using /MD when building JNI using Windows
* Disabled style check for windows by creating ciCheckWindows.
* Added a workaround for std::wstring_convert<std::codecvt_utf8_utf16<char16_t>, char16_t>() undefined when using Visual Studio to build