### PR TITLE
Fix blob read and write stream not getting closed

### DIFF
--- a/lib/src/shared/main/java/com/couchbase/lite/internal/core/C4BlobReadStream.java
+++ b/lib/src/shared/main/java/com/couchbase/lite/internal/core/C4BlobReadStream.java
@@ -77,9 +77,9 @@ public class C4BlobReadStream {
         final long hdl = handle;
         handle = 0L;
 
-        if (hdl != 0L) { return; }
+        if (hdl == 0L) { return; }
 
-        close(handle);
+        close(hdl);
     }
 
     //-------------------------------------------------------------------------

--- a/lib/src/shared/main/java/com/couchbase/lite/internal/core/C4BlobWriteStream.java
+++ b/lib/src/shared/main/java/com/couchbase/lite/internal/core/C4BlobWriteStream.java
@@ -95,7 +95,7 @@ public class C4BlobWriteStream {
 
         if (hdl == 0L) { return; }
 
-        close(handle);
+        close(hdl);
     }
 
     //-------------------------------------------------------------------------


### PR DESCRIPTION
- Fixed blob stream not getting close in C4BlobReadStream.close() and C4BlobWriteStream.close() method.
- This issue was uncovered when running the unit tests on Windows as the database cannot be deleted if there is something still holding on to it.