### PR TITLE
Concurrent executor failover to serial queue

### DIFF
--- a/lib/src/shared/main/java/com/couchbase/lite/internal/AbstractExecutionService.java
+++ b/lib/src/shared/main/java/com/couchbase/lite/internal/AbstractExecutionService.java
@@ -301,15 +301,15 @@ public abstract class AbstractExecutionService implements ExecutionService {
 
             dumpServiceState(executor, "size: " + running, ex);
 
-            Log.d(DOMAIN, "==== Concurrent Executor status: " + this);
-            if (needsRestart) { Log.d(DOMAIN, "= stalled"); }
+            Log.w(DOMAIN, "==== Concurrent Executor status: " + this);
+            if (needsRestart) { Log.w(DOMAIN, "= stalled"); }
 
-            if (current != null) { Log.d(DOMAIN, "== Current task: " + current, current.origin); }
+            if (current != null) { Log.w(DOMAIN, "== Current task: " + current, current.origin); }
 
             final ArrayList<InstrumentedTask> waiting = new ArrayList<>(pendingTasks);
-            Log.d(DOMAIN, "== Pending tasks: " + waiting.size());
+            Log.w(DOMAIN, "== Pending tasks: " + waiting.size());
             int n = 0;
-            for (InstrumentedTask t : waiting) { Log.d(DOMAIN, "@" + (++n) + ": " + t, t.origin); }
+            for (InstrumentedTask t : waiting) { Log.w(DOMAIN, "@" + (++n) + ": " + t, t.origin); }
         }
     }
 
@@ -419,21 +419,21 @@ public abstract class AbstractExecutionService implements ExecutionService {
 
             dumpServiceState(executor, "size: " + pendingTasks.size(), ex);
 
-            Log.d(DOMAIN, "==== Serial Executor status: " + this);
-            if (needsRestart) { Log.d(DOMAIN, "= stalled"); }
+            Log.w(DOMAIN, "==== Serial Executor status: " + this);
+            if (needsRestart) { Log.w(DOMAIN, "= stalled"); }
 
-            if (prev != null) { Log.d(DOMAIN, "== Previous task: " + prev, prev.origin); }
+            if (prev != null) { Log.w(DOMAIN, "== Previous task: " + prev, prev.origin); }
 
-            if (pendingTasks.isEmpty()) { Log.d(DOMAIN, "== Queue is empty"); }
+            if (pendingTasks.isEmpty()) { Log.w(DOMAIN, "== Queue is empty"); }
             else {
                 final ArrayList<InstrumentedTask> waiting = new ArrayList<>(pendingTasks);
 
                 final InstrumentedTask current = waiting.remove(0);
-                Log.d(DOMAIN, "== Current task: " + current, current.origin);
+                Log.w(DOMAIN, "== Current task: " + current, current.origin);
 
-                Log.d(DOMAIN, "== Pending tasks: " + waiting.size());
+                Log.w(DOMAIN, "== Pending tasks: " + waiting.size());
                 int n = 0;
-                for (InstrumentedTask t : waiting) { Log.d(DOMAIN, "@" + (++n) + ": " + t, t.origin); }
+                for (InstrumentedTask t : waiting) { Log.w(DOMAIN, "@" + (++n) + ": " + t, t.origin); }
             }
         }
     }
@@ -444,23 +444,23 @@ public abstract class AbstractExecutionService implements ExecutionService {
     static void dumpServiceState(@NonNull Executor ex, @NonNull String msg, @Nullable Exception e) {
         if (throttled()) { return; }
 
-        Log.d(LogDomain.DATABASE, "====== Catastrophic failure of executor " + ex + ": " + msg, e);
+        Log.w(LogDomain.DATABASE, "====== Catastrophic failure of executor " + ex + ": " + msg, e);
 
         final Map<Thread, StackTraceElement[]> stackTraces = Thread.getAllStackTraces();
-        Log.d(DOMAIN, "==== Threads: " + stackTraces.size());
+        Log.w(DOMAIN, "==== Threads: " + stackTraces.size());
         for (Map.Entry<Thread, StackTraceElement[]> stack : stackTraces.entrySet()) {
-            Log.d(DOMAIN, "== Thread: " + stack.getKey());
-            for (StackTraceElement frame : stack.getValue()) { Log.d(DOMAIN, "      at " + frame); }
+            Log.w(DOMAIN, "== Thread: " + stack.getKey());
+            for (StackTraceElement frame : stack.getValue()) { Log.w(DOMAIN, "      at " + frame); }
         }
 
         if (!(ex instanceof ThreadPoolExecutor)) { return; }
 
         final ArrayList<Runnable> waiting = new ArrayList<>(((ThreadPoolExecutor) ex).getQueue());
-        Log.d(DOMAIN, "==== Executor queue: " + waiting.size());
+        Log.w(DOMAIN, "==== Executor queue: " + waiting.size());
         int n = 0;
         for (Runnable r : waiting) {
             final Exception orig = (!(r instanceof InstrumentedTask)) ? null : ((InstrumentedTask) r).origin;
-            Log.d(DOMAIN, "@" + (n++) + ": " + r, orig);
+            Log.w(DOMAIN, "@" + (n++) + ": " + r, orig);
         }
     }
 

--- a/lib/src/shared/main/java/com/couchbase/lite/internal/ExecutionService.java
+++ b/lib/src/shared/main/java/com/couchbase/lite/internal/ExecutionService.java
@@ -29,11 +29,11 @@ public interface ExecutionService {
      * They simply get to say that they are done with it
      */
     interface CloseableExecutor extends Executor {
-        class ExecutorClosedExeception extends RejectedExecutionException {
-            public ExecutorClosedExeception() {}
-            public ExecutorClosedExeception(String msg) { super(msg); }
-            public ExecutorClosedExeception(String msg, Throwable err) { super(msg, err); }
-            public ExecutorClosedExeception(Throwable err) { super(err); }
+        class ExecutorClosedException extends RejectedExecutionException {
+            public ExecutorClosedException() {}
+            public ExecutorClosedException(String msg) { super(msg); }
+            public ExecutorClosedException(String msg, Throwable err) { super(msg, err); }
+            public ExecutorClosedException(Throwable err) { super(err); }
         }
 
         /**

--- a/lib/src/shared/test/java/com/couchbase/lite/internal/ExecutionServicesTest.kt
+++ b/lib/src/shared/test/java/com/couchbase/lite/internal/ExecutionServicesTest.kt
@@ -17,46 +17,55 @@ package com.couchbase.lite.internal
 
 import com.couchbase.lite.CouchbaseLite
 import com.couchbase.lite.LogDomain
+import com.couchbase.lite.PlatformBaseTest
 import com.couchbase.lite.internal.support.Log
-
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertTrue
 import org.junit.Assert.fail
+import org.junit.Before
+import org.junit.Ignore
 import org.junit.Test
-
 import java.util.Stack
+import java.util.concurrent.ArrayBlockingQueue
 import java.util.concurrent.CountDownLatch
+import java.util.concurrent.Executor
 import java.util.concurrent.RejectedExecutionException
+import java.util.concurrent.ThreadPoolExecutor
 import java.util.concurrent.TimeUnit
 
 
-// This currently tests the AndroidExecutionService, on a device.
-// It should test the current implementation of ExecutionService, on a VM
-class ExecutionServicesTest {
-    private val executionService = CouchbaseLite.getExecutionService()
+class ExecutionServicesTest : PlatformBaseTest() {
+    private val capacity = AbstractExecutionService.MIN_CAPACITY * 2
 
-    // The main executor always uses the same thread.
-    @Test
-    fun testMainThreadExecutor() {
-        val latch = CountDownLatch(2)
+    private val queue = ArrayBlockingQueue<Runnable>(capacity)
 
-        val threads = arrayOfNulls<Thread>(2)
+    private val baseExecutor = ThreadPoolExecutor(3, 3, 5, TimeUnit.SECONDS, queue)
 
-        executionService.mainExecutor.execute {
-            threads[0] = Thread.currentThread()
-            latch.countDown()
+    private val baseService = object : AbstractExecutionService(baseExecutor) {
+        override fun postDelayedOnExecutor(
+            delayMs: Long,
+            executor: Executor,
+            task: Runnable
+        ): ExecutionService.Cancellable {
+            throw UnsupportedOperationException()
         }
 
-        executionService.mainExecutor.execute {
-            threads[1] = Thread.currentThread()
-            latch.countDown()
+        override fun cancelDelayedTask(future: ExecutionService.Cancellable) {
+            throw UnsupportedOperationException()
         }
 
-        try { latch.await(2, TimeUnit.SECONDS) }
-        catch (ignore: InterruptedException) { }
+        override fun getMainExecutor(): Executor {
+            throw UnsupportedOperationException()
+        }
+    }
 
-        assertEquals(threads[0], threads[1])
+    private lateinit var cblService: ExecutionService
+
+    @Before
+    fun setUp() {
+        initCouchbaseLite()
+        cblService = CouchbaseLite.getExecutionService()
     }
 
     // The serial executor executes in order.
@@ -67,14 +76,14 @@ class ExecutionServicesTest {
 
         val stack = Stack<String>()
 
-        val executor = executionService.serialExecutor
+        val executor = baseService.serialExecutor
 
         executor.execute {
             try {
                 startLatch.await() // wait for the 2nd task to be scheduled.
                 Thread.sleep(1000)
+            } catch (ignore: InterruptedException) {
             }
-            catch (ignore: InterruptedException) { }
 
             synchronized(stack) { stack.push("ONE") }
 
@@ -89,8 +98,10 @@ class ExecutionServicesTest {
         // allow the first task to proceed.
         startLatch.countDown()
 
-        try {finishLatch.await(5, TimeUnit.SECONDS) }
-        catch (ignore: InterruptedException) {  }
+        try {
+            finishLatch.await(5, TimeUnit.SECONDS)
+        } catch (ignore: InterruptedException) {
+        }
 
         synchronized(stack) {
             assertEquals("TWO", stack.pop())
@@ -98,32 +109,36 @@ class ExecutionServicesTest {
         }
     }
 
-    // A stopped executor throws on further attempts to schedule
+    // A stopped serial executor throws on further attempts to schedule
     @Test(expected = RejectedExecutionException::class)
     fun testStoppedSerialExecutorRejects() {
-        val executor = executionService.serialExecutor
+        val executor = baseService.serialExecutor
         assertTrue(executor.stop(0, TimeUnit.SECONDS)) // no tasks
         executor.execute { Log.d(LogDomain.DATABASE, "This test is about to fail!") }
     }
 
-    // A stopped executor can finish currently queued tasks.
+    // A stopped serial executor can finish currently queued tasks.
     @Test
     fun testStoppedSerialExecutorCompletes() {
         val startLatch = CountDownLatch(1)
         val finishLatch = CountDownLatch(2)
 
-        val executor = executionService.serialExecutor
+        val executor = baseService.serialExecutor
 
         executor.execute {
-            try { startLatch.await() }
-            catch (ignore: InterruptedException) { }
+            try {
+                startLatch.await()
+            } catch (ignore: InterruptedException) {
+            }
 
             finishLatch.countDown()
         }
 
         executor.execute {
-            try { startLatch.await() }
-            catch (ignore: InterruptedException) { }
+            try {
+                startLatch.await()
+            } catch (ignore: InterruptedException) {
+            }
 
             finishLatch.countDown()
         }
@@ -133,19 +148,21 @@ class ExecutionServicesTest {
         try {
             executor.execute { Log.d(LogDomain.DATABASE, "This test is about to fail!") }
             fail("Stopped executor should not accept new tasks")
+        } catch (expected: RejectedExecutionException) {
         }
-        catch (expected: RejectedExecutionException) { }
 
         // allow the tasks to proceed.
         startLatch.countDown()
 
-        try { assertTrue(finishLatch.await(5, TimeUnit.SECONDS)) }
-        catch (ignore: InterruptedException) { }
+        try {
+            assertTrue(finishLatch.await(5, TimeUnit.SECONDS))
+        } catch (ignore: InterruptedException) {
+        }
 
         assertTrue(executor.stop(5, TimeUnit.SECONDS)) // everything should be done shortly
     }
 
-    // The concurrent executor can executes out of order.
+    // The concurrent executor can execute out of order.
     @Test
     fun testConcurrentExecutor() {
         val startLatch = CountDownLatch(1)
@@ -153,14 +170,14 @@ class ExecutionServicesTest {
 
         val stack = Stack<String>()
 
-        val executor = executionService.concurrentExecutor
+        val executor = baseService.concurrentExecutor
 
         executor.execute {
             try {
                 startLatch.await() // wait for the 2nd task to be scheduled.
                 Thread.sleep(1000)
+            } catch (ignore: InterruptedException) {
             }
-            catch (ignore: InterruptedException) { }
 
             synchronized(stack) { stack.push("ONE") }
 
@@ -175,8 +192,10 @@ class ExecutionServicesTest {
         // allow the first task to proceed.
         startLatch.countDown()
 
-        try { finishLatch.await(5, TimeUnit.SECONDS) }
-        catch (ignore: InterruptedException) { }
+        try {
+            finishLatch.await(5, TimeUnit.SECONDS)
+        } catch (ignore: InterruptedException) {
+        }
 
         // tasks should finish in reverse start order
         synchronized(stack) {
@@ -185,39 +204,58 @@ class ExecutionServicesTest {
         }
     }
 
-    // A stopped Executor throws on further attempts to schedule
-    @Test(expected = RejectedExecutionException::class)
-    fun testStoppedConcurrentExecutorRejects() {
-        val executor = executionService.concurrentExecutor
-        assertTrue(executor.stop(0, TimeUnit.SECONDS)) // no tasks
-        try {
-            executor.execute { Log.d(LogDomain.DATABASE, "This test is about to fail!") }
+    // A concurrent executor fails over before swamping the underlying executor's queue
+    @Test
+    fun testConcurrentExecutorFailover() {
+        val nTasks = capacity * 2
+
+        val startLatch = CountDownLatch(1)
+        val finishLatch = CountDownLatch(nTasks)
+
+        val executor = baseService.concurrentExecutor
+
+        // Queue up more tasks than the base executor has room for.
+        // This should work...
+        for (i in 0 until nTasks) {
+            executor.execute {
+                try {
+                    startLatch.await(1, TimeUnit.SECONDS)
+                } catch (ignore: InterruptedException) {
+                } finally {
+                    finishLatch.countDown()
+                }
+            }
         }
-        finally {
-            // Restart concurrent executor
-            (executionService as AbstractExecutionService).restartConcurrentExecutor()
-        }
+
+        // Set all of the tasks free
+        startLatch.countDown()
+
+        assertTrue(finishLatch.await(1, TimeUnit.SECONDS))
     }
 
-    // A stopped Executor finishes currently queued tasks.
+    // A stopped concurrent executor finishes currently queued tasks.
     @Test
     fun testStoppedConcurrentExecutorCompletes() {
         val startLatch = CountDownLatch(1)
         val finishLatch = CountDownLatch(2)
 
-        val executor = executionService.concurrentExecutor
+        val executor = baseService.concurrentExecutor
 
         // enqueue two tasks
         executor.execute {
-            try { startLatch.await() }
-            catch (ignore: InterruptedException) { }
+            try {
+                startLatch.await()
+            } catch (ignore: InterruptedException) {
+            }
 
             finishLatch.countDown()
         }
 
         executor.execute {
-            try { startLatch.await() }
-            catch (ignore: InterruptedException) { }
+            try {
+                startLatch.await()
+            } catch (ignore: InterruptedException) {
+            }
 
             finishLatch.countDown()
         }
@@ -227,19 +265,51 @@ class ExecutionServicesTest {
         try {
             executor.execute { Log.d(LogDomain.DATABASE, "This test is about to fail!") }
             fail("Stopped executor should not accept new tasks")
+        } catch (expected: RejectedExecutionException) {
         }
-        catch (expected: RejectedExecutionException) { }
 
         // allow the tasks to proceed.
         startLatch.countDown()
 
-        try { assertTrue(finishLatch.await(5, TimeUnit.SECONDS)) }
-        catch (ignore: InterruptedException) { }
+        try {
+            assertTrue(finishLatch.await(5, TimeUnit.SECONDS))
+        } catch (ignore: InterruptedException) {
+        }
 
         assertTrue(executor.stop(5, TimeUnit.SECONDS)) // everything should be done shortly
+    }
 
-        // Restart concurrent executor
-        (executionService as AbstractExecutionService).restartConcurrentExecutor()
+    // A stopped concurrent executor throws on further attempts to schedule
+    @Test(expected = RejectedExecutionException::class)
+    fun testStoppedConcurrentExecutorRejects() {
+        val executor = baseService.concurrentExecutor
+        assertTrue(executor.stop(0, TimeUnit.SECONDS)) // no tasks
+        executor.execute { Log.d(LogDomain.DATABASE, "This test is about to fail!") }
+    }
+
+    // The main executor always uses the same thread.
+    @Test
+    fun testMainThreadExecutor() {
+        val latch = CountDownLatch(2)
+
+        val threads = arrayOfNulls<Thread>(2)
+
+        cblService.mainExecutor.execute {
+            threads[0] = Thread.currentThread()
+            latch.countDown()
+        }
+
+        cblService.mainExecutor.execute {
+            threads[1] = Thread.currentThread()
+            latch.countDown()
+        }
+
+        try {
+            latch.await(2, TimeUnit.SECONDS)
+        } catch (ignore: InterruptedException) {
+        }
+
+        assertEquals(threads[0], threads[1])
     }
 
     // The scheduler schedules on the passed queue, with the proper delay.
@@ -249,7 +319,7 @@ class ExecutionServicesTest {
 
         val threads = arrayOfNulls<Thread>(2)
 
-        val executor = executionService.mainExecutor
+        val executor = cblService.mainExecutor
 
         // get the thread used by the executor
         // note that only the mainThreadExecutor guarantees execution on a single thread...
@@ -257,17 +327,19 @@ class ExecutionServicesTest {
 
         var t = System.currentTimeMillis()
         val delay: Long = 777
-        executionService.postDelayedOnExecutor(
-                delay,
-                executor,
-                Runnable {
-                    t = System.currentTimeMillis() - t
-                    threads[1] = Thread.currentThread()
-                    finishLatch.countDown()
-                })
+        cblService.postDelayedOnExecutor(
+            delay,
+            executor,
+            Runnable {
+                t = System.currentTimeMillis() - t
+                threads[1] = Thread.currentThread()
+                finishLatch.countDown()
+            })
 
-        try { assertTrue(finishLatch.await(5, TimeUnit.SECONDS)) }
-        catch (ignore: InterruptedException) { }
+        try {
+            assertTrue(finishLatch.await(5, TimeUnit.SECONDS))
+        } catch (ignore: InterruptedException) {
+        }
 
         // within 10% is good enough
         assertEquals(0L, (t - delay) / (delay / 10))
@@ -281,16 +353,56 @@ class ExecutionServicesTest {
 
         // schedule far enough in the future so that there is plenty of time to cancel it
         // but not so far that we have to wait a long tim to be sure it didn't run.
-        val task = executionService.postDelayedOnExecutor(
-                100,
-                executionService.concurrentExecutor,
-                Runnable { completed[0] = true })
+        val task = cblService.postDelayedOnExecutor(
+            100,
+            baseService.concurrentExecutor,
+            Runnable { completed[0] = true })
 
-        executionService.cancelDelayedTask(task)
+        cblService.cancelDelayedTask(task)
 
-        try { Thread.sleep(200) }
-        catch (ignore: InterruptedException) { }
+        try {
+            Thread.sleep(200)
+        } catch (ignore: InterruptedException) {
+        }
 
         assertFalse(completed[0])
+    }
+
+    @Ignore("This is not actually a test.  Use it to verify logcat output")
+    @Test(expected = RejectedExecutionException::class)
+    fun testSerialExecutorFailure() {
+        val executor = baseService.serialExecutor
+
+        // hang the queue
+        val latch = CountDownLatch(1)
+        executor.execute {
+            try {
+                latch.await(2, TimeUnit.SECONDS)
+            } catch (ignore: InterruptedException) {
+            }
+        }
+
+        // put some stuff in the serial executor queue
+        for (i in 1..9) {
+            executor.execute { }
+        }
+
+        // fill the base executor.
+        try {
+            while (true) {
+                baseExecutor.execute {
+                    try {
+                        Thread.sleep(1000) // sleep for a second
+                    } catch (ignore: InterruptedException) {
+                    }
+                }
+            }
+        } catch (ignore: RejectedExecutionException) {
+        }
+
+        // this should free the running serial job,
+        // which should fail trying to start the next job
+        // which should log a bunch of stuff.
+        latch.countDown()
     }
 }


### PR DESCRIPTION
There are two important changes, here:
1) The parallel executor will never use the last MIN_CAPACITY (currently 64) slots of a bounded executor queue.  That leave a fair amount of space for serial queues (2 slots per queue) and other application stuff.
2) When the parallel executor exhausts execution resources (availCapacity - MIN_CAPACITY <= 0) it fails over to using an unbounded serial queue.  This means that the failure mode for, e.g., conflict revolvers that permanently block all execution, will be an eventual OOM.  Before the OOM warnings will be logged to help identify the actual problem.  Unfortunately, though, because the queue is unbounded, there will be no helpful execution queue dump.
All tests passing on all platforms