### PR TITLE
CBL-571 : Fix linux build issue on Jenkins

### DIFF
--- a/etc/jenkins/build_linux.sh
+++ b/etc/jenkins/build_linux.sh
@@ -37,8 +37,13 @@ $CBL_JAVA_DIR/scripts/fetch_litecore.sh -n $LITE_CORE_REPO_URL -v linux -e $EDIT
 echo "======== Building mbedcrypto ..."
 $CBL_JAVA_DIR/scripts/build_litecore.sh -e $EDITION -l mbedcrypto
 
+# Set load library path for building and testing:
 SUPPORT_DIR="${CBL_JAVA_DIR}/lite-core/support/linux/x86_64"
 export LD_LIBRARY_PATH="${SUPPORT_DIR}/libicu:${SUPPORT_DIR}/libz:${SUPPORT_DIR}/libc++"
+
+# Set libc++ include and lib directory from cbdeps:
+echo "LINUX_LIBCXX_INCDIR=${LIBCXX_INCDIR}/c++/v1" >> local.properties
+echo "LINUX_LIBCXX_LIBDIR=${LIBCXX_LIBDIR}" >> local.properties
 
 echo "======== Build Couchbase Lite Java, $EDITION v`cat ../version.txt`-${BUILD_NUMBER}"
 ./gradlew ciCheck -PbuildNumber="${BUILD_NUMBER}" --info || exit 1

--- a/lib/build.gradle
+++ b/lib/build.gradle
@@ -240,13 +240,14 @@ model {
                     cppCompiler.args '-stdlib=libc++'
                     linker.args '-stdlib=libc++'
                 } else if (targetPlatform.operatingSystem.linux) {
-                    if (project.hasProperty("cxxIncludeDir")) {
-                        cppCompiler.args '-isystem', project.property('cxxIncludeDir')
-                    }
+                    def libCxxIncDir = properties.getProperty('LINUX_LIBCXX_INCDIR')
+                    if (libCxxIncDir != null) { cppCompiler.args '-isystem', libCxxIncDir }
                     cppCompiler.args '-I', "${JAVA_HOME}/include"
                     cppCompiler.args '-I', "${JAVA_HOME}/include/linux"
                     cppCompiler.args '-std=c++11'
                     cppCompiler.args '-stdlib=libc++'
+                    def libCxxLibDir = properties.getProperty('LINUX_LIBCXX_LIBDIR')
+                    if (libCxxLibDir != null) { linker.args '-L', libCxxLibDir }
                     linker.args '-stdlib=libc++'
                 } else if (targetPlatform.operatingSystem.windows) {
                     cppCompiler.args "-I${JAVA_HOME}/include"

--- a/scripts/build_litecore.sh
+++ b/scripts/build_litecore.sh
@@ -79,7 +79,7 @@ if [[ $OS == linux ]]; then
   fi
 
   if [[ $LIB == mbedcrypto ]]; then
-    CC=clang CXX=clang++ cmake -DCMAKE_BUILD_TYPE=RelWithDebInfo -DCMAKE_C_COMPILER_WORKS=1 -DCMAKE_CXX_COMPILER_WORKS=1 ../../vendor/mbedtls
+    CC=clang CXX=clang++ cmake -DCMAKE_BUILD_TYPE=RelWithDebInfo -DCMAKE_POSITION_INDEPENDENT_CODE=1 ../../vendor/mbedtls
     make -j `expr $CORE_COUNT + 1`
     cp -f library/libmbedcrypto.a $OUTPUT_DIR
   fi
@@ -98,7 +98,7 @@ if [[ $OS == macos ]]; then
   fi
 
   if [[ $LIB == mbedcrypto ]]; then
-    cmake -DBUILD_ENTERPRISE=$ENT -DCMAKE_BUILD_TYPE=RelWithDebInfo ../../vendor/mbedtls
+    cmake -DBUILD_ENTERPRISE=$ENT -DCMAKE_BUILD_TYPE=RelWithDebInfo -DCMAKE_POSITION_INDEPENDENT_CODE=1 ../../vendor/mbedtls
     make -j `expr $CORE_COUNT + 1`
     cp -f library/libmbedcrypto.a $OUTPUT_DIR
   fi


### PR DESCRIPTION
- Support libc++ library deployed at a custom location.
- Allow to build mbedcrypto by using its cmake directly without going through LiteCore's cmake.
- Enable DCMAKE_POSITION_INDEPENDENT_CODE when directly cmaking mbedcryoto.

Note: 
1. The two commits has been cherry-picked from the master.
2. The fix has been verified as the linux build on Jenkins is now successful.

Reference: https://issues.couchbase.com/browse/CBL-571