### PR TITLE
Thread-safe C4Document

### DIFF
--- a/lib/src/shared/main/java/com/couchbase/lite/internal/core/C4Document.java
+++ b/lib/src/shared/main/java/com/couchbase/lite/internal/core/C4Document.java
@@ -91,14 +91,14 @@ public class C4Document extends RefCounted {
     public boolean selectNextRevision() { return withHandle(C4Document::selectNextRevision, false); }
 
     public void selectNextLeafRevision(boolean includeDeleted, boolean withBody) throws LiteCoreException {
-        withHandleVoid(h -> selectNextLeafRevision(handle, includeDeleted, withBody));
+        withHandleVoid(h -> selectNextLeafRevision(h, includeDeleted, withBody));
     }
 
     // - Purging and Expiration
 
     public void resolveConflict(String winningRevID, String losingRevID, byte[] mergeBody, int mergedFlags)
         throws LiteCoreException {
-        withHandleVoid(h -> resolveConflict(handle, winningRevID, losingRevID, mergeBody, mergedFlags));
+        withHandleVoid(h -> resolveConflict(h, winningRevID, losingRevID, mergeBody, mergedFlags));
     }
 
     // - Creating and Updating Documents
@@ -117,7 +117,7 @@ public class C4Document extends RefCounted {
     // -- Fleece-related
 
     public String bodyAsJSON(boolean canonical) throws LiteCoreException {
-        return withHandleThrows(h -> bodyAsJSON(handle, canonical), null);
+        return withHandleThrows(h -> bodyAsJSON(h, canonical), null);
     }
 
     // helper methods for Document
@@ -194,7 +194,7 @@ public class C4Document extends RefCounted {
     private <T> T withHandle(Fn.Function<Long, T> fn, T def) {
         synchronized (lock) {
             if (handle != 0) { return fn.apply(handle); }
-            Log.w(LogDomain.DATABASE, "Function called on freed object", new Exception());
+            Log.w(LogDomain.DATABASE, "Function called on freed C4Document", new Exception());
             return def;
         }
     }
@@ -202,7 +202,7 @@ public class C4Document extends RefCounted {
     private <T> T withHandleThrows(Fn.FunctionThrows<Long, T, LiteCoreException> fn, T def) throws LiteCoreException {
         synchronized (lock) {
             if (handle != 0) { return fn.apply(handle); }
-            Log.w(LogDomain.DATABASE, "Function called on freed object", new Exception());
+            Log.w(LogDomain.DATABASE, "Function called on freed C4Document", new Exception());
             return def;
         }
     }
@@ -213,7 +213,7 @@ public class C4Document extends RefCounted {
                 fn.accept(handle);
                 return;
             }
-            Log.w(LogDomain.DATABASE, "Function called on freed object", new Exception());
+            Log.w(LogDomain.DATABASE, "Function called on freed C4Document", new Exception());
         }
     }
 

--- a/lib/src/shared/main/java/com/couchbase/lite/internal/core/C4Document.java
+++ b/lib/src/shared/main/java/com/couchbase/lite/internal/core/C4Document.java
@@ -17,10 +17,17 @@
 //
 package com.couchbase.lite.internal.core;
 
+import android.support.annotation.GuardedBy;
+import android.support.annotation.NonNull;
+
 import com.couchbase.lite.LiteCoreException;
+import com.couchbase.lite.LogDomain;
 import com.couchbase.lite.internal.fleece.FLDict;
 import com.couchbase.lite.internal.fleece.FLSharedKeys;
 import com.couchbase.lite.internal.fleece.FLSliceResult;
+import com.couchbase.lite.internal.support.Log;
+import com.couchbase.lite.internal.utils.Preconditions;
+import com.couchbase.lite.utils.Fn;
 
 
 public class C4Document extends RefCounted {
@@ -29,79 +36,195 @@ public class C4Document extends RefCounted {
     }
 
     //-------------------------------------------------------------------------
+    // Member Variables
+    //-------------------------------------------------------------------------
+
+    @NonNull
+    private final Object lock = new Object(); // lock for thread-safety
+
+    @GuardedBy("lock")
+    private long handle; // hold pointer to C4Document
+
+    //-------------------------------------------------------------------------
     // Constructor
+    //-------------------------------------------------------------------------
+    C4Document(long db, String docID, boolean mustExist) throws LiteCoreException { this(get(db, docID, mustExist)); }
+
+    C4Document(long db, long sequence) throws LiteCoreException { this(getBySequence(db, sequence)); }
+
+    C4Document(long handle) {
+        Preconditions.checkArgNotZero(handle, "handle");
+        this.handle = handle;
+    }
+
+    //-------------------------------------------------------------------------
+    // public methods
     //-------------------------------------------------------------------------
 
     // - C4Document
-    static native int getFlags(long doc);
 
-    static native String getDocID(long doc);
+    public int getFlags() { return withHandle(C4Document::getFlags, 0); }
 
-    static native String getRevID(long doc);
-
-    static native long getSequence(long doc);
-
-    static native String getSelectedRevID(long doc);
-
-    static native int getSelectedFlags(long doc);
-
-    static native long getSelectedSequence(long doc);
-
-    static native byte[] getSelectedBody(long doc);
+    public String getDocID() { return withHandle(C4Document::getDocID, null); }
 
     // - C4Revision
 
-    // return pointer to FLValue
-    static native long getSelectedBody2(long doc);
+    public String getRevID() { return withHandle(C4Document::getRevID, null); }
 
-    static native long get(long db, String docID, boolean mustExist)
-        throws LiteCoreException;
+    public long getSequence() { return withHandle(C4Document::getSequence, 0L); }
 
-    static native long getBySequence(long db, long sequence) throws LiteCoreException;
-
-    static native void save(long doc, int maxRevTreeDepth) throws LiteCoreException;
-
-    static native void free(long doc);
+    public String getSelectedRevID() { return withHandle(C4Document::getSelectedRevID, null); }
 
     // - Lifecycle
 
-    static native boolean selectCurrentRevision(long doc);
+    public long getSelectedSequence() { return withHandle(C4Document::getSelectedSequence, 0L); }
+
+    public FLDict getSelectedBody2() {
+        final long value = withHandle(C4Document::getSelectedBody2, null);
+        return value == 0 ? null : new FLDict(value);
+    }
+
+    public void save(int maxRevTreeDepth) throws LiteCoreException { withHandleVoid(h -> save(h, maxRevTreeDepth)); }
 
     // - Revisions
 
-    static native void loadRevisionBody(long doc) throws LiteCoreException;
+    public boolean selectNextRevision() { return withHandle(C4Document::selectNextRevision, false); }
 
-    static native boolean hasRevisionBody(long doc);
+    public void selectNextLeafRevision(boolean includeDeleted, boolean withBody) throws LiteCoreException {
+        withHandleVoid(h -> selectNextLeafRevision(handle, includeDeleted, withBody));
+    }
 
-    static native boolean selectParentRevision(long doc);
+    // - Purging and Expiration
 
-    static native boolean selectNextRevision(long doc);
-
-    static native void selectNextLeafRevision(
-        long doc, boolean includeDeleted,
-        boolean withBody)
-        throws LiteCoreException;
-
-    static native boolean selectFirstPossibleAncestorOf(long doc, String revID);
-
-    static native boolean selectNextPossibleAncestorOf(long doc, String revID);
-
-    static native boolean selectCommonAncestorRevision(
-        long doc,
-        String revID1, String revID2);
-
-    static native int purgeRevision(long doc, String revID) throws LiteCoreException;
-
-    static native void resolveConflict(
-        long doc,
-        String winningRevID, String losingRevID,
-        byte[] mergeBody, int mergedFlags)
-        throws LiteCoreException;
-
-    static native void setExpiration(long db, String docID, long timestamp)
-        throws LiteCoreException;
+    public void resolveConflict(String winningRevID, String losingRevID, byte[] mergeBody, int mergedFlags)
+        throws LiteCoreException {
+        withHandleVoid(h -> resolveConflict(handle, winningRevID, losingRevID, mergeBody, mergedFlags));
+    }
 
     // - Creating and Updating Documents
+
+    public C4Document update(byte[] body, int flags) throws LiteCoreException {
+        final long newDoc = withHandleThrows(h -> update(h, body, flags), 0L);
+        return (newDoc == 0) ? null : new C4Document(newDoc);
+    }
+
+    public C4Document update(FLSliceResult body, int flags) throws LiteCoreException {
+        final long bodyHandle = (body != null) ? body.getHandle() : 0;
+        final long newDoc = withHandleThrows(h -> update2(h, bodyHandle, flags), 0L);
+        return (newDoc == 0) ? null : new C4Document(newDoc);
+    }
+
+    // -- Fleece-related
+
+    public String bodyAsJSON(boolean canonical) throws LiteCoreException {
+        return withHandleThrows(h -> bodyAsJSON(handle, canonical), null);
+    }
+
+    // helper methods for Document
+    public boolean deleted() { return isSelectedRevFlags(C4Constants.RevisionFlags.DELETED); }
+
+    public boolean exists() { return isFlags(C4Constants.DocumentFlags.EXISTS); }
+
+    public boolean isSelectedRevFlags(int flag) { return (getSelectedFlags() & flag) == flag; }
+
+    //-------------------------------------------------------------------------
+    // protected methods
+    //-------------------------------------------------------------------------
+
+    @SuppressWarnings("NoFinalizer")
+    @Override
+    protected void finalize() throws Throwable {
+        free();
+        super.finalize();
+    }
+
+    //-------------------------------------------------------------------------
+    // package protected methods
+    //-------------------------------------------------------------------------
+
+    int getSelectedFlags() { return withHandle(C4Document::getSelectedFlags, 0); }
+
+    byte[] getSelectedBody() { return withHandle(C4Document::getSelectedBody, null); }
+
+    boolean selectCurrentRevision() { return withHandle(C4Document::selectCurrentRevision, false); }
+
+    void loadRevisionBody() throws LiteCoreException { withHandleVoid(C4Document::loadRevisionBody); }
+
+    boolean hasRevisionBody() { return withHandle(C4Document::hasRevisionBody, false); }
+
+    boolean selectParentRevision() { return withHandle(C4Document::selectParentRevision, false); }
+
+    boolean selectFirstPossibleAncestorOf(String revID) {
+        return withHandle(h -> selectFirstPossibleAncestorOf(h, revID), false);
+    }
+
+    boolean selectNextPossibleAncestorOf(String revID) {
+        return withHandle(h -> selectNextPossibleAncestorOf(h, revID), false);
+    }
+
+    boolean selectCommonAncestorRevision(String revID1, String revID2) {
+        return withHandle(h -> selectCommonAncestorRevision(h, revID1, revID2), false);
+    }
+
+    int purgeRevision(String revID) throws LiteCoreException {
+        return withHandleThrows(h -> purgeRevision(h, revID), 0);
+    }
+
+    @Override
+    void free() {
+        final long hdl;
+        synchronized (lock) {
+            hdl = handle;
+            handle = 0;
+        }
+
+        if (hdl != 0L) { free(hdl); }
+    }
+
+    //-------------------------------------------------------------------------
+    // private methods
+    //-------------------------------------------------------------------------
+
+    private boolean isFlags(int flag) { return (getFlags() & flag) == flag; }
+
+    private boolean conflicted() { return isFlags(C4Constants.DocumentFlags.CONFLICTED); }
+
+    private boolean accessRemoved() { return isSelectedRevFlags(C4Constants.RevisionFlags.PURGED); }
+
+    private <T> T withHandle(Fn.Function<Long, T> fn, T def) {
+        synchronized (lock) {
+            if (handle != 0) { return fn.apply(handle); }
+            Log.w(LogDomain.DATABASE, "Function called on freed object", new Exception());
+            return def;
+        }
+    }
+
+    private <T> T withHandleThrows(Fn.FunctionThrows<Long, T, LiteCoreException> fn, T def) throws LiteCoreException {
+        synchronized (lock) {
+            if (handle != 0) { return fn.apply(handle); }
+            Log.w(LogDomain.DATABASE, "Function called on freed object", new Exception());
+            return def;
+        }
+    }
+
+    private void withHandleVoid(Fn.ConsumerThrows<Long, LiteCoreException> fn) throws LiteCoreException {
+        synchronized (lock) {
+            if (handle != 0) {
+                fn.accept(handle);
+                return;
+            }
+            Log.w(LogDomain.DATABASE, "Function called on freed object", new Exception());
+        }
+    }
+
+    //-------------------------------------------------------------------------
+    // native methods
+    //-------------------------------------------------------------------------
+
+
+    // - helper methods
+
+    static native void setExpiration(long db, String docID, long timestamp) throws LiteCoreException;
 
     static native long getExpiration(long db, String docID) throws LiteCoreException;
 
@@ -117,10 +240,6 @@ public class C4Document extends RefCounted {
         int maxRevTreeDepth,
         int remoteDBID)
         throws LiteCoreException;
-
-    //-------------------------------------------------------------------------
-    // helper methods
-    //-------------------------------------------------------------------------
 
     static native long put2(
         long db,
@@ -139,199 +258,82 @@ public class C4Document extends RefCounted {
 
     static native long create2(long db, String docID, long body, int flags) throws LiteCoreException;
 
-    static native long update(long doc, byte[] body, int flags) throws LiteCoreException;
-
-    static native long update2(long doc, long body, int flags) throws LiteCoreException;
-
-    static native boolean dictContainsBlobs(long dict, long sk); // dict -> FLSliceResult
-
-    //-------------------------------------------------------------------------
-    // Fleece-related
-    //-------------------------------------------------------------------------
-
-    static native String bodyAsJSON(long doc, boolean canonical) throws LiteCoreException;
-    //-------------------------------------------------------------------------
-    // Member Variables
-    //-------------------------------------------------------------------------
-    private long handle; // hold pointer to C4Document
-
-    C4Document(long db, String docID, boolean mustExist) throws LiteCoreException {
-        this(get(db, docID, mustExist));
-    }
-
-    //-------------------------------------------------------------------------
-    // native methods
-    //-------------------------------------------------------------------------
-
-    C4Document(long db, long sequence) throws LiteCoreException {
-        this(getBySequence(db, sequence));
-    }
-
-    C4Document(long handle) {
-        if (handle == 0) { throw new IllegalArgumentException("handle is 0"); }
-        this.handle = handle;
-    }
-
-    //-------------------------------------------------------------------------
-    // public methods
-    //-------------------------------------------------------------------------
-    @Override
-    void free() {
-        if (handle != 0L) {
-            free(handle);
-            handle = 0L;
-        }
-    }
-
     // - C4Document
-    public int getFlags() {
-        return getFlags(handle);
-    }
+
+    private static native int getFlags(long doc);
+
+    private static native String getDocID(long doc);
 
     // - C4Revision
 
-    public String getDocID() {
-        return getDocID(handle);
-    }
+    private static native String getRevID(long doc);
 
-    public String getRevID() {
-        return getRevID(handle);
-    }
+    private static native long getSequence(long doc);
 
-    public long getSequence() {
-        return getSequence(handle);
-    }
+    private static native String getSelectedRevID(long doc);
 
-    public String getSelectedRevID() {
-        return getSelectedRevID(handle);
-    }
-
-    public int getSelectedFlags() {
-        return getSelectedFlags(handle);
-    }
+    private static native int getSelectedFlags(long doc);
 
     // - Lifecycle
 
-    public long getSelectedSequence() {
-        return getSelectedSequence(handle);
-    }
+    private static native long getSelectedSequence(long doc);
 
-    public byte[] getSelectedBody() {
-        return getSelectedBody(handle);
-    }
+    private static native byte[] getSelectedBody(long doc);
 
-    public FLDict getSelectedBody2() {
-        final long value = getSelectedBody2(handle);
-        return value == 0 ? null : new FLDict(value);
-    }
+    // return pointer to FLValue
+    private static native long getSelectedBody2(long doc);
 
-    public void save(int maxRevTreeDepth) throws LiteCoreException {
-        save(handle, maxRevTreeDepth);
-    }
+    private static native long get(long db, String docID, boolean mustExist) throws LiteCoreException;
+
+    private static native long getBySequence(long db, long sequence) throws LiteCoreException;
+
+    private static native void save(long doc, int maxRevTreeDepth) throws LiteCoreException;
+
+    private static native void free(long doc);
 
     // - Revisions
 
-    public boolean selectCurrentRevision() {
-        return selectCurrentRevision(handle);
-    }
+    private static native boolean selectCurrentRevision(long doc);
 
-    public void loadRevisionBody() throws LiteCoreException {
-        loadRevisionBody(handle);
-    }
+    private static native void loadRevisionBody(long doc) throws LiteCoreException;
 
-    public boolean hasRevisionBody() {
-        return hasRevisionBody(handle);
-    }
+    private static native boolean hasRevisionBody(long doc);
 
-    public boolean selectParentRevision() {
-        return selectParentRevision(handle);
-    }
+    private static native boolean selectParentRevision(long doc);
 
-    public boolean selectNextRevision() {
-        return selectNextRevision(handle);
-    }
+    private static native boolean selectNextRevision(long doc);
 
-    public void selectNextLeafRevision(boolean includeDeleted, boolean withBody)
-        throws LiteCoreException {
-        selectNextLeafRevision(handle, includeDeleted, withBody);
-    }
+    private static native void selectNextLeafRevision(
+        long doc,
+        boolean includeDeleted,
+        boolean withBody)
+        throws LiteCoreException;
 
-    public boolean selectFirstPossibleAncestorOf(String revID) throws LiteCoreException {
-        return selectFirstPossibleAncestorOf(handle, revID);
-    }
+    private static native boolean selectFirstPossibleAncestorOf(long doc, String revID);
 
-    public boolean selectNextPossibleAncestorOf(String revID) {
-        return selectNextPossibleAncestorOf(handle, revID);
-    }
+    private static native boolean selectNextPossibleAncestorOf(long doc, String revID);
 
-    public boolean selectCommonAncestorRevision(String revID1, String revID2) {
-        return selectCommonAncestorRevision(handle, revID1, revID2);
-    }
+    private static native boolean selectCommonAncestorRevision(long doc, String revID1, String revID2);
 
-    public int purgeRevision(String revID) throws LiteCoreException {
-        return purgeRevision(handle, revID);
-    }
+    private static native int purgeRevision(long doc, String revID) throws LiteCoreException;
 
-    public void resolveConflict(String winningRevID, String losingRevID, byte[] mergeBody, int mergedFlags)
-        throws LiteCoreException {
-        resolveConflict(handle, winningRevID, losingRevID, mergeBody, mergedFlags);
-    }
+    private static native void resolveConflict(
+        long doc,
+        String winningRevID,
+        String losingRevID,
+        byte[] mergeBody,
+        int mergedFlags)
+        throws LiteCoreException;
 
     // - Purging and Expiration
 
-    public C4Document update(byte[] body, int flags) throws LiteCoreException {
-        return new C4Document(update(handle, body, flags));
-    }
+    private static native long update(long doc, byte[] body, int flags) throws LiteCoreException;
 
-    public C4Document update(FLSliceResult body, int flags) throws LiteCoreException {
-        return new C4Document(update2(handle, body != null ? body.getHandle() : 0, flags));
-    }
+    private static native long update2(long doc, long body, int flags) throws LiteCoreException;
 
-    // - Creating and Updating Documents
+    // - Fleece-related
 
-    // helper methods for Document
-    public boolean deleted() {
-        return isSelectedRevFlags(C4Constants.RevisionFlags.DELETED);
-    }
+    private static native String bodyAsJSON(long doc, boolean canonical) throws LiteCoreException;
 
-    public boolean accessRemoved() {
-        return isSelectedRevFlags(C4Constants.RevisionFlags.PURGED);
-    }
-
-    public boolean conflicted() {
-        return isFlags(C4Constants.DocumentFlags.CONFLICTED);
-    }
-
-    public boolean exists() {
-        return isFlags(C4Constants.DocumentFlags.EXISTS);
-    }
-
-    private boolean isFlags(int flag) {
-        return (getFlags(handle) & flag) == flag;
-    }
-
-    public boolean isSelectedRevFlags(int flag) {
-        return (getSelectedFlags(handle) & flag) == flag;
-    }
-
-    ////////////////////////////////
-    // c4Document+Fleece.h
-    ////////////////////////////////
-
-    // -- Fleece-related
-
-    public String bodyAsJSON(boolean canonical) throws LiteCoreException {
-        return bodyAsJSON(handle, canonical);
-    }
-
-    //-------------------------------------------------------------------------
-    // protected methods
-    //-------------------------------------------------------------------------
-    @SuppressWarnings("NoFinalizer")
-    @Override
-    protected void finalize() throws Throwable {
-        free();
-        super.finalize();
-    }
-    // doc -> pointer to C4Document
+    private static native boolean dictContainsBlobs(long dict, long sk); // dict -> FLSliceResult
 }

--- a/lib/src/shared/main/java/com/couchbase/lite/internal/support/Log.java
+++ b/lib/src/shared/main/java/com/couchbase/lite/internal/support/Log.java
@@ -392,7 +392,7 @@ public final class Log {
         if ((args != null) && (args.length > 0)) { message = formatMessage(message, args); }
 
         if (err != null) {
-            StringWriter sw = new StringWriter();
+            final StringWriter sw = new StringWriter();
             err.printStackTrace(new PrintWriter(sw));
             message += System.lineSeparator() + sw.toString();
         }

--- a/lib/src/shared/main/java/com/couchbase/lite/internal/support/Log.java
+++ b/lib/src/shared/main/java/com/couchbase/lite/internal/support/Log.java
@@ -20,6 +20,8 @@ package com.couchbase.lite.internal.support;
 import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
 
+import java.io.PrintWriter;
+import java.io.StringWriter;
 import java.util.Collections;
 import java.util.EnumSet;
 import java.util.FormatterClosedException;
@@ -389,7 +391,11 @@ public final class Log {
 
         if ((args != null) && (args.length > 0)) { message = formatMessage(message, args); }
 
-        if (err != null) { message = message + " (" + err + ")"; }
+        if (err != null) {
+            StringWriter sw = new StringWriter();
+            err.printStackTrace(new PrintWriter(sw));
+            message += System.lineSeparator() + sw.toString();
+        }
 
         sendToLoggers(level, domain, message);
     }

--- a/lib/src/shared/main/java/com/couchbase/lite/utils/Fn.java
+++ b/lib/src/shared/main/java/com/couchbase/lite/utils/Fn.java
@@ -26,5 +26,7 @@ public interface Fn {
     @FunctionalInterface
     interface Provider<T> { T get(); }
     @FunctionalInterface
+    interface ConsumerThrows<T, E extends Throwable> { void accept(T x) throws E; }
+    @FunctionalInterface
     interface Consumer<T> { void accept(T x); }
 }

--- a/lib/src/shared/test/java/com/couchbase/lite/LogTest.java
+++ b/lib/src/shared/test/java/com/couchbase/lite/LogTest.java
@@ -313,6 +313,8 @@ public class LogTest extends BaseTest {
 
     @Test
     public void testBasicLogFormatting() {
+        String nl = System.lineSeparator();
+
         BasicLogger logger = new BasicLogger();
         Database.log.setCustom(logger);
 
@@ -320,14 +322,16 @@ public class LogTest extends BaseTest {
         assertEquals("TEST DEBUG", logger.getMessage());
 
         Log.d(LogDomain.DATABASE, "TEST DEBUG", new Exception("whoops"));
-        assertEquals("TEST DEBUG (java.lang.Exception: whoops)", logger.getMessage());
+        assertTrue(logger.getMessage().startsWith(
+            "TEST DEBUG" + nl + "java.lang.Exception: whoops" + System.lineSeparator()));
 
         // test formatting, including argument ordering
         Log.d(LogDomain.DATABASE, "TEST DEBUG %2$s %1$d %3$.2f", 1, "arg", 3.0F);
         assertEquals("TEST DEBUG arg 1 3.00", logger.getMessage());
 
         Log.d(LogDomain.DATABASE, "TEST DEBUG %2$s %1$d %3$.2f", new Exception("whoops"), 1, "arg", 3.0F);
-        assertEquals("TEST DEBUG arg 1 3.00 (java.lang.Exception: whoops)", logger.getMessage());
+        assertTrue(logger.getMessage().startsWith(
+            "TEST DEBUG arg 1 3.00" + nl + "java.lang.Exception: whoops" + nl));
     }
 
     @Test
@@ -467,6 +471,8 @@ public class LogTest extends BaseTest {
 
     @Test
     public void testLogStandardErrorWithFormatting() {
+        String nl = System.lineSeparator();
+
         Map<String, String> stdErr = new HashMap<>();
         stdErr.put("FOO", "TEST DEBUG %2$s %1$d %3$.2f");
         try {
@@ -476,7 +482,8 @@ public class LogTest extends BaseTest {
             Database.log.setCustom(logger);
 
             Log.d(LogDomain.DATABASE, "FOO", new Exception("whoops"), 1, "arg", 3.0F);
-            assertEquals("TEST DEBUG arg 1 3.00 (java.lang.Exception: whoops)", logger.getMessage());
+            assertTrue(logger.getMessage().startsWith(
+                "TEST DEBUG arg 1 3.00" + nl + "java.lang.Exception: whoops" + nl));
         }
         finally {
             reloadStandardErrorMessages();


### PR DESCRIPTION
While we did not succeed in root-causing CBL-583, it is pretty clear what the problem was: the C4Document code was wildly non-thread-safe.  This code should make it thread-safe and also corrects some loosey-goosey visibility.

This is another near-rewrite.  It might make more sense to just read the code, than to try to read the diffs.

I am currently developing a minimal subset of this change, for Mercury.