### PR TITLE
CBL-583: Prevent localDoc object to be collected

### DIFF
--- a/lib/src/shared/main/java/com/couchbase/lite/AbstractDatabase.java
+++ b/lib/src/shared/main/java/com/couchbase/lite/AbstractDatabase.java
@@ -1345,7 +1345,8 @@ abstract class AbstractDatabase {
             rawDoc.resolveConflict(remoteDoc.getRevisionID(), localDoc.getRevisionID(), mergedBodyBytes, mergedFlags);
             rawDoc.save(0);
 
-            Log.i(DOMAIN, "Conflict resolved as doc '%s' rev %s", rawDoc.getDocID(), rawDoc.getRevID());
+            // CBL-583: Keep localDoc object to be alive until the end by using localDoc to get the doc id.
+            Log.i(DOMAIN, "Conflict resolved as doc '%s' rev %s", localDoc.getId(), rawDoc.getRevID());
         }
         catch (LiteCoreException e) {
             throw CBLStatus.convertException(e);


### PR DESCRIPTION
It seems like localDoc could be collected before the end of saveResolvedDocument(). The speculation is that the JIT optimizer might think that localDoc hasn’t been used anymore after the line that gets the rawDoc (C4Document) from the localDoc so it could be collected.

From repeatedly running the test, this little trick by trying to use the localDoc until the end could help keeping the localDoc alive until the end. 

Reference: https://issues.couchbase.com/browse/CBL-583