### PR TITLE
CBL-164: Move CouchbaseLite.getExecutionService() out of the public API

### DIFF
--- a/lib/src/main/java/com/couchbase/lite/CouchbaseLite.java
+++ b/lib/src/main/java/com/couchbase/lite/CouchbaseLite.java
@@ -18,100 +18,21 @@
 package com.couchbase.lite;
 
 import android.support.annotation.NonNull;
-import android.support.annotation.VisibleForTesting;
+import android.support.annotation.Nullable;
 
 import java.io.File;
-import java.io.IOException;
-import java.io.InputStream;
-import java.util.Map;
-import java.util.Properties;
-import java.util.concurrent.atomic.AtomicBoolean;
-import java.util.concurrent.atomic.AtomicReference;
 
-import com.couchbase.lite.internal.ExecutionService;
-import com.couchbase.lite.internal.JavaExecutionService;
+import com.couchbase.lite.internal.CouchbaseLiteInternal;
 import com.couchbase.lite.internal.fleece.MValue;
-import com.couchbase.lite.internal.support.Log;
 
 
 public final class CouchbaseLite {
     // Utility class
     private CouchbaseLite() {}
 
-    private static final String ERRORS_PROPERTIES_PATH = "/errors.properties";
+    public static void init() { init(new MValueDelegate(), false, null); }
 
-    private static final AtomicBoolean INITIALIZED = new AtomicBoolean(false);
-
-    private static final AtomicReference<ExecutionService> EXECUTION_SERVICE = new AtomicReference<>();
-
-    /**
-     * Initialize CouchbaseLite library. This method MUST be called before
-     * using CouchbaseLite.
-     */
-    public static void init() {
-        if (INITIALIZED.getAndSet(true)) { return; }
-
-        NativeLibrary.load();
-
-        MValue.registerDelegate(new MValueDelegate());
-
-        Log.initLogging(loadErrorMessages());
-    }
-
-    /**
-     * This method is for internal used only and will be removed in the future release.
-     */
-    public static ExecutionService getExecutionService() {
-        ExecutionService executionService = EXECUTION_SERVICE.get();
-        if (executionService == null) {
-            EXECUTION_SERVICE.compareAndSet(null, new JavaExecutionService());
-            executionService = EXECUTION_SERVICE.get();
-        }
-        return executionService;
-    }
-
-    static void requireInit(String message) {
-        if (!INITIALIZED.get()) {
-            throw new IllegalStateException(message + ".  Did you forget to call CouchbaseLite.init()?");
-        }
-    }
-
-    static String getDbDirectoryPath() {
-        requireInit("Database directory not initialized");
-        return verifyDir(new File("").getAbsoluteFile());
-    }
-
-    static String getTmpDirectory(@NonNull String name) {
-        requireInit("Temp directory not initialized");
-        return getTmpDirectory(new File(System.getProperty("java.io.tmpdir")).getAbsolutePath(), name);
-    }
-
-    static String getTmpDirectory(String root, String name) {
-        requireInit("Temp directory not initialized");
-        return verifyDir(new File(root, name));
-    }
-
-    @VisibleForTesting
-    static void reset() { INITIALIZED.set(false); }
-
-    @VisibleForTesting
-    @SuppressWarnings("unchecked")
-    @NonNull
-    static Map<String, String> loadErrorMessages() {
-        final Properties errors = new Properties();
-        try (InputStream is = CouchbaseLite.class.getResourceAsStream(ERRORS_PROPERTIES_PATH)){
-            errors.load(is);
-        } catch (IOException e) {
-            Log.e(LogDomain.DATABASE, "Failed to load error messages!", e);
-        }
-        return (Map<String, String>) (Map) errors;
-    }
-
-    @NonNull
-    private static String verifyDir(@NonNull File dir) {
-        final String path = dir.getAbsolutePath();
-        if ((dir.exists() || dir.mkdirs()) && dir.isDirectory()) { return path; }
-
-        throw new IllegalStateException("Cannot create or access temp directory at " + path);
+    private static void init(@NonNull MValue.Delegate mValueDelegate, boolean debugging, @Nullable File rootDirectory) {
+        CouchbaseLiteInternal.init(mValueDelegate, debugging, rootDirectory);
     }
 }

--- a/lib/src/main/java/com/couchbase/lite/internal/CouchbaseLiteInternal.java
+++ b/lib/src/main/java/com/couchbase/lite/internal/CouchbaseLiteInternal.java
@@ -1,0 +1,116 @@
+//
+// Copyright (c) 2019 Couchbase, Inc All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+package com.couchbase.lite.internal;
+
+import android.support.annotation.NonNull;
+import android.support.annotation.Nullable;
+import android.support.annotation.VisibleForTesting;
+
+import java.io.File;
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.Map;
+import java.util.Properties;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicReference;
+
+import com.couchbase.lite.LogDomain;
+import com.couchbase.lite.internal.fleece.MValue;
+import com.couchbase.lite.internal.support.Log;
+
+
+public final class CouchbaseLiteInternal {
+    // Utility class
+    private CouchbaseLiteInternal() {}
+
+    private static final String ERRORS_PROPERTIES_PATH = "/errors.properties";
+
+    private static final AtomicReference<ExecutionService> EXECUTION_SERVICE = new AtomicReference<>();
+
+    private static final AtomicBoolean INITIALIZED = new AtomicBoolean(false);
+
+    /**
+     * Initialize CouchbaseLite library. This method MUST be called before
+     * using CouchbaseLite.
+     */
+    public static void init(@NonNull MValue.Delegate mValueDelegate, boolean debugging, @Nullable File rootDirectory) {
+        if (INITIALIZED.getAndSet(true)) { return; }
+
+        NativeLibrary.load();
+
+        MValue.registerDelegate(mValueDelegate);
+
+        Log.initLogging(loadErrorMessages());
+    }
+
+    public static boolean isDebugging() { return false; }
+
+    /**
+     * This method is for internal used only and will be removed in the future release.
+     */
+    public static ExecutionService getExecutionService() {
+        ExecutionService executionService = EXECUTION_SERVICE.get();
+        if (executionService == null) {
+            EXECUTION_SERVICE.compareAndSet(null, new JavaExecutionService());
+            executionService = EXECUTION_SERVICE.get();
+        }
+        return executionService;
+    }
+
+    public static void requireInit(String message) {
+        if (!INITIALIZED.get()) {
+            throw new IllegalStateException(message + ".  Did you forget to call CouchbaseLite.init()?");
+        }
+    }
+
+    public static String getDbDirectoryPath() {
+        requireInit("Database directory not initialized");
+        return verifyDir(new File("").getAbsoluteFile());
+    }
+
+    public static String getTmpDirectory(@NonNull String name) {
+        requireInit("Temp directory not initialized");
+        return getTmpDirectory(new File(System.getProperty("java.io.tmpdir")).getAbsolutePath(), name);
+    }
+
+    public static String getTmpDirectory(String root, String name) {
+        requireInit("Temp directory not initialized");
+        return verifyDir(new File(root, name));
+    }
+
+    @VisibleForTesting
+    public static void reset() { INITIALIZED.set(false); }
+
+    @VisibleForTesting
+    @SuppressWarnings("unchecked")
+    @NonNull
+    public static Map<String, String> loadErrorMessages() {
+        final Properties errors = new Properties();
+        try (InputStream is = CouchbaseLiteInternal.class.getResourceAsStream(ERRORS_PROPERTIES_PATH)) {
+            errors.load(is);
+        }
+        catch (IOException e) { Log.e(LogDomain.DATABASE, "Failed to load error messages!", e); }
+        return (Map<String, String>) (Map) errors;
+    }
+
+    @NonNull
+    private static String verifyDir(@NonNull File dir) {
+        final String path = dir.getAbsolutePath();
+        if ((dir.exists() || dir.mkdirs()) && dir.isDirectory()) { return path; }
+
+        throw new IllegalStateException("Cannot create or access temp directory at " + path);
+    }
+}

--- a/lib/src/main/java/com/couchbase/lite/internal/NativeLibrary.java
+++ b/lib/src/main/java/com/couchbase/lite/internal/NativeLibrary.java
@@ -15,7 +15,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 //
-package com.couchbase.lite;
+package com.couchbase.lite.internal;
 
 import android.support.annotation.NonNull;
 
@@ -31,11 +31,12 @@ import java.util.concurrent.atomic.AtomicBoolean;
 
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 
+
 /**
  * For extracting and loading native libraries for couchbase-lite-java.
  */
 final class NativeLibrary {
-    private static final String[] LIBRARIES = { "LiteCore", "LiteCoreJNI" };
+    private static final String[] LIBRARIES = {"LiteCore", "LiteCoreJNI"};
 
     private static final String LIBS_RES_BASE_DIR = "/libs";
 
@@ -66,7 +67,8 @@ final class NativeLibrary {
      * directory will be <System Temp Directory>/com.couchbase.lite.java/native/<MD5-Hash>.
      * The MD5-Hash is the combined MD5 hash of the hashes of all native libraries.
      */
-    @NonNull @SuppressFBWarnings("DE_MIGHT_IGNORE")
+    @NonNull
+    @SuppressFBWarnings("DE_MIGHT_IGNORE")
     private static String getTargetDirectory(@NonNull String[] libPaths)
         throws NoSuchAlgorithmException, IOException {
         final MessageDigest md = MessageDigest.getInstance("MD5");
@@ -85,15 +87,16 @@ final class NativeLibrary {
                 if (in != null) { try { in.close(); } catch (IOException e) { } }
             }
         }
-        final String md5 =  String.format("%032x", new BigInteger(1, md.digest()));
-        return new File(CouchbaseLite.getTmpDirectory(TARGET_BASE_DIR), md5).getAbsolutePath();
+        final String md5 = String.format("%032x", new BigInteger(1, md.digest()));
+        return new File(CouchbaseLiteInternal.getTmpDirectory(TARGET_BASE_DIR), md5).getAbsolutePath();
     }
 
     /**
      * Extracts the given path to the native library in the resource directory into the target directory.
      * If the native library already exists in the target library, the existing native library will be used.
      */
-    @NonNull @SuppressFBWarnings("DE_MIGHT_IGNORE")
+    @NonNull
+    @SuppressFBWarnings("DE_MIGHT_IGNORE")
     private static File extract(@NonNull String libResPath, @NonNull String targetDir)
         throws IOException, InterruptedException {
         final File targetFile = new File(targetDir, new File(libResPath).getName());
@@ -146,7 +149,7 @@ final class NativeLibrary {
         else { path += "/" + osName; }
 
         // Arch:
-        final String archName  = "x86_64";
+        final String archName = "x86_64";
         path += '/' + archName;
 
         // Platform specific name part of path.

--- a/lib/src/shared/main/java/com/couchbase/lite/AbstractDatabase.java
+++ b/lib/src/shared/main/java/com/couchbase/lite/AbstractDatabase.java
@@ -39,6 +39,7 @@ import org.json.JSONException;
 
 import com.couchbase.lite.internal.CBLInternalException;
 import com.couchbase.lite.internal.CBLStatus;
+import com.couchbase.lite.internal.CouchbaseLiteInternal;
 import com.couchbase.lite.internal.ExecutionService;
 import com.couchbase.lite.internal.SocketFactory;
 import com.couchbase.lite.internal.core.C4BlobStore;
@@ -259,7 +260,7 @@ abstract class AbstractDatabase {
         if (StringUtils.isEmpty(name)) { throw new IllegalArgumentException("db name may not be empty"); }
         Preconditions.checkArgNotNull(config, "config");
 
-        CouchbaseLite.requireInit("Cannot create database");
+        CouchbaseLiteInternal.requireInit("Cannot create database");
 
         // Name:
         this.name = name;
@@ -268,8 +269,8 @@ abstract class AbstractDatabase {
         this.config = config.readonlyCopy();
 
         this.shellMode = false;
-        this.postExecutor = CouchbaseLite.getExecutionService().getSerialExecutor();
-        this.queryExecutor = CouchbaseLite.getExecutionService().getSerialExecutor();
+        this.postExecutor = CouchbaseLiteInternal.getExecutionService().getSerialExecutor();
+        this.queryExecutor = CouchbaseLiteInternal.getExecutionService().getSerialExecutor();
         this.activeLiveQueries = Collections.synchronizedSet(new HashSet<>());
 
         // synchronized on 'lock'
@@ -998,11 +999,11 @@ abstract class AbstractDatabase {
     //////// Execution:
 
     void scheduleOnPostNotificationExecutor(@NonNull Runnable task, long delayMs) {
-        CouchbaseLite.getExecutionService().postDelayedOnExecutor(delayMs, postExecutor, task);
+        CouchbaseLiteInternal.getExecutionService().postDelayedOnExecutor(delayMs, postExecutor, task);
     }
 
     void scheduleOnQueryExecutor(@NonNull Runnable task, long delayMs) {
-        CouchbaseLite.getExecutionService().postDelayedOnExecutor(delayMs, queryExecutor, task);
+        CouchbaseLiteInternal.getExecutionService().postDelayedOnExecutor(delayMs, queryExecutor, task);
     }
 
     abstract int getEncryptionAlgorithm();

--- a/lib/src/shared/main/java/com/couchbase/lite/AbstractDatabaseConfiguration.java
+++ b/lib/src/shared/main/java/com/couchbase/lite/AbstractDatabaseConfiguration.java
@@ -18,6 +18,7 @@ package com.couchbase.lite;
 
 import android.support.annotation.NonNull;
 
+import com.couchbase.lite.internal.CouchbaseLiteInternal;
 import com.couchbase.lite.internal.core.C4Base;
 
 
@@ -39,7 +40,7 @@ abstract class AbstractDatabaseConfiguration {
     //---------------------------------------------
 
     protected AbstractDatabaseConfiguration() {
-        this(false, CouchbaseLite.getDbDirectoryPath());
+        this(false, CouchbaseLiteInternal.getDbDirectoryPath());
     }
 
     protected AbstractDatabaseConfiguration(@NonNull AbstractDatabaseConfiguration config) {
@@ -121,7 +122,7 @@ abstract class AbstractDatabaseConfiguration {
      */
     private String getTempDir() {
         return (!customDir)
-            ? CouchbaseLite.getTmpDirectory(TEMP_DIR_NAME)
-            : CouchbaseLite.getTmpDirectory(directory, TEMP_DIR_NAME);
+            ? CouchbaseLiteInternal.getTmpDirectory(TEMP_DIR_NAME)
+            : CouchbaseLiteInternal.getTmpDirectory(directory, TEMP_DIR_NAME);
     }
 }

--- a/lib/src/shared/main/java/com/couchbase/lite/ChangeListenerToken.java
+++ b/lib/src/shared/main/java/com/couchbase/lite/ChangeListenerToken.java
@@ -22,6 +22,8 @@ import android.support.annotation.Nullable;
 
 import java.util.concurrent.Executor;
 
+import com.couchbase.lite.internal.CouchbaseLiteInternal;
+
 
 class ChangeListenerToken<T> implements ListenerToken {
     @NonNull
@@ -41,7 +43,9 @@ class ChangeListenerToken<T> implements ListenerToken {
     public void setKey(Object key) { this.key = key; }
 
     void postChange(final T change) {
-        final Executor exec = (executor != null) ? executor : CouchbaseLite.getExecutionService().getMainExecutor();
+        final Executor exec = (executor != null)
+            ? executor
+            : CouchbaseLiteInternal.getExecutionService().getMainExecutor();
         exec.execute(() -> listener.changed(change));
     }
 }

--- a/lib/src/shared/main/java/com/couchbase/lite/DocumentExpirationStrategy.java
+++ b/lib/src/shared/main/java/com/couchbase/lite/DocumentExpirationStrategy.java
@@ -19,8 +19,10 @@ import android.support.annotation.NonNull;
 
 import java.util.concurrent.Executor;
 
+import com.couchbase.lite.internal.CouchbaseLiteInternal;
 import com.couchbase.lite.internal.ExecutionService.Cancellable;
 import com.couchbase.lite.internal.support.Log;
+
 
 /**
  * Expire documents at a regular interval, once started.
@@ -52,7 +54,7 @@ class DocumentExpirationStrategy {
         final long delayMs = Math.max(nextExpiration - System.currentTimeMillis(), minDelayMs);
         synchronized (this) {
             if (expirationCancelled || (expirationTask != null)) { return; }
-            expirationTask = CouchbaseLite.getExecutionService()
+            expirationTask = CouchbaseLiteInternal.getExecutionService()
                 .postDelayedOnExecutor(delayMs, expirationExecutor, this::purgeExpiredDocuments);
         }
 
@@ -68,7 +70,7 @@ class DocumentExpirationStrategy {
 
         if (task == null) { return; }
 
-        CouchbaseLite.getExecutionService().cancelDelayedTask(task);
+        CouchbaseLiteInternal.getExecutionService().cancelDelayedTask(task);
     }
 
     // Aligning with database/document change notification to avoid race condition

--- a/lib/src/shared/main/java/com/couchbase/lite/Log.java
+++ b/lib/src/shared/main/java/com/couchbase/lite/Log.java
@@ -20,6 +20,8 @@ package com.couchbase.lite;
 import android.support.annotation.NonNull;
 import android.support.annotation.VisibleForTesting;
 
+import com.couchbase.lite.internal.CouchbaseLiteInternal;
+
 
 /**
  * Gets the log controller for Couchbase Lite, which stores the
@@ -46,7 +48,7 @@ public final class Log {
      */
     @NonNull
     public ConsoleLogger getConsole() {
-        CouchbaseLite.requireInit("Console logging not initialized");
+        CouchbaseLiteInternal.requireInit("Console logging not initialized");
         return consoleLogger;
     }
 
@@ -57,7 +59,7 @@ public final class Log {
      */
     @NonNull
     public FileLogger getFile() {
-        CouchbaseLite.requireInit("File logging not initialized");
+        CouchbaseLiteInternal.requireInit("File logging not initialized");
         return fileLogger;
     }
 

--- a/lib/src/shared/main/java/com/couchbase/lite/ReplicatorChangeListenerToken.java
+++ b/lib/src/shared/main/java/com/couchbase/lite/ReplicatorChangeListenerToken.java
@@ -19,6 +19,8 @@ package com.couchbase.lite;
 
 import java.util.concurrent.Executor;
 
+import com.couchbase.lite.internal.CouchbaseLiteInternal;
+
 
 final class ReplicatorChangeListenerToken implements ListenerToken {
     private final ReplicatorChangeListener listener;
@@ -33,7 +35,7 @@ final class ReplicatorChangeListenerToken implements ListenerToken {
     void notify(final ReplicatorChange change) { getExecutor().execute(() -> listener.changed(change)); }
 
     Executor getExecutor() {
-        return (executor != null) ? executor : CouchbaseLite.getExecutionService().getMainExecutor();
+        return (executor != null) ? executor : CouchbaseLiteInternal.getExecutionService().getMainExecutor();
     }
 }
 
@@ -50,6 +52,6 @@ final class DocumentReplicationListenerToken implements ListenerToken {
     void notify(final DocumentReplication update) { getExecutor().execute(() -> listener.replication(update)); }
 
     Executor getExecutor() {
-        return (executor != null) ? executor : CouchbaseLite.getExecutionService().getMainExecutor();
+        return (executor != null) ? executor : CouchbaseLiteInternal.getExecutionService().getMainExecutor();
     }
 }

--- a/lib/src/shared/main/java/com/couchbase/lite/internal/core/C4Log.java
+++ b/lib/src/shared/main/java/com/couchbase/lite/internal/core/C4Log.java
@@ -21,11 +21,11 @@ import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
 
 import com.couchbase.lite.ConsoleLogger;
-import com.couchbase.lite.CouchbaseLite;
 import com.couchbase.lite.Database;
 import com.couchbase.lite.LogDomain;
 import com.couchbase.lite.LogLevel;
 import com.couchbase.lite.Logger;
+import com.couchbase.lite.internal.CouchbaseLiteInternal;
 import com.couchbase.lite.internal.support.Log;
 
 
@@ -71,7 +71,7 @@ public final class C4Log {
         // This cannot be done synchronously because it will deadlock
         // on the same mutex that is being held for this callback
         final int level = logLevel.getValue();
-        CouchbaseLite.getExecutionService().getMainExecutor().execute(() -> setCallbackLevel(level));
+        CouchbaseLiteInternal.getExecutionService().getMainExecutor().execute(() -> setCallbackLevel(level));
     }
 
     //-------------------------------------------------------------------------

--- a/lib/src/shared/test/java/com/couchbase/lite/BaseTest.java
+++ b/lib/src/shared/test/java/com/couchbase/lite/BaseTest.java
@@ -35,6 +35,7 @@ import org.junit.Before;
 import org.junit.Rule;
 import org.junit.rules.ExpectedException;
 
+import com.couchbase.lite.internal.CouchbaseLiteInternal;
 import com.couchbase.lite.internal.ExecutionService;
 import com.couchbase.lite.internal.utils.JsonUtils;
 import com.couchbase.lite.utils.FileUtils;
@@ -53,11 +54,17 @@ public abstract class BaseTest extends PlatformBaseTest {
     private static final int BUSY_WAIT_MS = 100;
     private static final int BUSY_RETRIES = 5;
 
-    interface Execution { void run() throws CouchbaseLiteException; }
+    interface Execution {
+        void run() throws CouchbaseLiteException;
+    }
 
-    interface DocValidator { void validate(final Document doc); }
+    interface DocValidator {
+        void validate(final Document doc);
+    }
 
-    interface QueryResult { void check(int n, Result result) throws Exception; }
+    interface QueryResult {
+        void check(int n, Result result) throws Exception;
+    }
 
 
     protected Database db;
@@ -77,7 +84,7 @@ public abstract class BaseTest extends PlatformBaseTest {
         Database.log.getConsole().setLevel(LogLevel.DEBUG);
         //setupFileLogging(); // if needed
 
-        executor = CouchbaseLite.getExecutionService().getSerialExecutor();
+        executor = CouchbaseLiteInternal.getExecutionService().getSerialExecutor();
         testFailure = new AtomicReference<>();
 
         dbDir = new File(getDatabaseDirectory(), "CBLTestDb");

--- a/lib/src/shared/test/java/com/couchbase/lite/PreInitTest.java
+++ b/lib/src/shared/test/java/com/couchbase/lite/PreInitTest.java
@@ -18,10 +18,12 @@ package com.couchbase.lite;
 import org.junit.Before;
 import org.junit.Test;
 
+import com.couchbase.lite.internal.CouchbaseLiteInternal;
+
 
 public class PreInitTest {
     @Before
-    public void setup() { CouchbaseLite.reset(); }
+    public void setup() { CouchbaseLiteInternal.reset(); }
 
     @Test(expected = IllegalStateException.class)
     public void testCreateDatabaseBeforeInit() throws CouchbaseLiteException {
@@ -30,11 +32,11 @@ public class PreInitTest {
 
     @Test(expected = IllegalStateException.class)
     public void testGetTmpDirectoryBeforeInit() {
-        CouchbaseLite.getTmpDirectory("fail");
+        CouchbaseLiteInternal.getTmpDirectory("fail");
     }
 
     @Test(expected = IllegalStateException.class)
     public void testGetDbDirectoryBeforeInit() {
-        CouchbaseLite.getDbDirectoryPath();
+        CouchbaseLiteInternal.getDbDirectoryPath();
     }
 }

--- a/lib/src/shared/test/java/com/couchbase/lite/ReplicatorChangeListenerTokenTest.java
+++ b/lib/src/shared/test/java/com/couchbase/lite/ReplicatorChangeListenerTokenTest.java
@@ -21,6 +21,8 @@ import java.util.concurrent.Executor;
 
 import org.junit.Test;
 
+import com.couchbase.lite.internal.CouchbaseLiteInternal;
+
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.fail;
 
@@ -55,6 +57,6 @@ public class ReplicatorChangeListenerTokenTest {
 
         // UI thread Executor
         token = new ReplicatorChangeListenerToken(null, listener);
-        assertEquals(CouchbaseLite.getExecutionService().getMainExecutor(), token.getExecutor());
+        assertEquals(CouchbaseLiteInternal.getExecutionService().getMainExecutor(), token.getExecutor());
     }
 }

--- a/lib/src/shared/test/java/com/couchbase/lite/internal/ExecutionServiceTest.kt
+++ b/lib/src/shared/test/java/com/couchbase/lite/internal/ExecutionServiceTest.kt
@@ -15,7 +15,6 @@
 //
 package com.couchbase.lite.internal
 
-import com.couchbase.lite.CouchbaseLite
 import com.couchbase.lite.LogDomain
 import com.couchbase.lite.PlatformBaseTest
 import com.couchbase.lite.internal.support.Log
@@ -65,7 +64,7 @@ class ExecutionServiceTest : PlatformBaseTest() {
     @Before
     fun setUp() {
         initCouchbaseLite()
-        cblService = CouchbaseLite.getExecutionService()
+        cblService = CouchbaseLiteInternal.getExecutionService()
     }
 
 

--- a/lib/src/test/java/com/couchbase/lite/PlatformBaseTest.java
+++ b/lib/src/test/java/com/couchbase/lite/PlatformBaseTest.java
@@ -19,6 +19,7 @@ package com.couchbase.lite;
 
 import java.io.InputStream;
 
+import com.couchbase.lite.internal.CouchbaseLiteInternal;
 import com.couchbase.lite.internal.ExecutionService;
 import com.couchbase.lite.internal.support.Log;
 
@@ -42,12 +43,12 @@ public abstract class PlatformBaseTest implements PlatformTest {
 
     @Override
     public String getDatabaseDirectory() {
-        return CouchbaseLite.getDbDirectoryPath();
+        return CouchbaseLiteInternal.getDbDirectoryPath();
     }
 
     @Override
     public String getTempDirectory(String name) {
-        return CouchbaseLite.getTmpDirectory(name);
+        return CouchbaseLiteInternal.getTmpDirectory(name);
     }
 
     @Override
@@ -57,12 +58,12 @@ public abstract class PlatformBaseTest implements PlatformTest {
 
     @Override
     public void executeAsync(long delayMs, Runnable task) {
-        ExecutionService executionService = CouchbaseLite.getExecutionService();
+        ExecutionService executionService = CouchbaseLiteInternal.getExecutionService();
         executionService.postDelayedOnExecutor(delayMs, executionService.getMainExecutor(), task);
     }
 
     @Override
     public void reloadStandardErrorMessages() {
-        Log.initLogging(CouchbaseLite.loadErrorMessages());
+        Log.initLogging(CouchbaseLiteInternal.loadErrorMessages());
     }
 }


### PR DESCRIPTION
Move most of CouchbaseLite to CouchbaseLiteInternal hiding CouchbaseLite.getExecutionService()

This is a coordinated update with the other three java family products. There are five changes:
1) move most functionality from CouchbaseLite to CouchbaseLiteInternal
2) rename references to CouchbaseLite to CouchbaseLiteInternal
3) move NativeLibrary to make it visible to CBLInternal
4) Add a debug flag in CBLInternal
5) Add debug-flag controlled release info to C4Document
