### PR TITLE
Force call to C4Log.setCallbackLevel

### DIFF
--- a/lib/src/shared/main/java/com/couchbase/lite/internal/support/Log.java
+++ b/lib/src/shared/main/java/com/couchbase/lite/internal/support/Log.java
@@ -75,7 +75,6 @@ public final class Log {
     }
 
     public static final Map<Integer, LogLevel> LOG_LEVEL_FROM_C4;
-
     static {
         final Map<Integer, LogLevel> m = new HashMap<>();
         for (LogLevel level : LogLevel.values()) { m.put(level.getValue(), level); }
@@ -88,6 +87,7 @@ public final class Log {
      * Setup logging.
      */
     public static void initLogging(@NonNull Map<String, String> errorMessages) {
+        C4Log.setCallbackLevel(Database.log.getConsole().getLevel());
         setC4LogLevel(LogDomain.ALL_DOMAINS, LogLevel.DEBUG);
 
         Log.errorMessages = Collections.unmodifiableMap(errorMessages);


### PR DESCRIPTION
As noted in https://issues.couchbase.com/browse/CBL-607,  because the console logger's log level is initialized to WARNING, the call to tell core to initialize its log lever to WARNING is ignored.  This has the side effect of not initializing the logger callback method, so core used its default: logging directly to Android.

Any call to ConsoleLogger.setLevel() will work around the problem.
