### PR TITLE
Change memory management strategy for C4Document (CBL-601)

### DIFF
--- a/lib/src/shared/main/java/com/couchbase/lite/DocContext.java
+++ b/lib/src/shared/main/java/com/couchbase/lite/DocContext.java
@@ -29,19 +29,13 @@ class DocContext extends MContext {
     private final Database db;
     private final C4Document doc;
 
+    DocContext(Database db) { this(db, null); }
+
     DocContext(Database db, C4Document doc) {
         super(null);
         this.db = db;
         this.doc = doc;
-        if (this.doc != null) { this.doc.retain(); }
     }
 
     Database getDatabase() { return db; }
-
-    @SuppressWarnings("NoFinalizer")
-    @Override
-    protected void finalize() throws Throwable {
-        if (doc != null) { doc.release(); }
-        super.finalize();
-    }
 }

--- a/lib/src/shared/main/java/com/couchbase/lite/QueryChange.java
+++ b/lib/src/shared/main/java/com/couchbase/lite/QueryChange.java
@@ -18,6 +18,7 @@
 package com.couchbase.lite;
 
 import android.support.annotation.NonNull;
+import android.support.annotation.Nullable;
 
 
 /**
@@ -28,14 +29,17 @@ public final class QueryChange {
     //---------------------------------------------
     // member variables
     //---------------------------------------------
+    @NonNull
     private final Query query;
+    @Nullable
     private final ResultSet rs;
+    @Nullable
     private final Throwable error;
 
     //---------------------------------------------
     // constructors
     //---------------------------------------------
-    QueryChange(Query query, ResultSet rs, Throwable error) {
+    QueryChange(@NonNull Query query, @Nullable ResultSet rs, @Nullable Throwable error) {
         this.query = query;
         this.rs = rs;
         this.error = error;
@@ -49,22 +53,17 @@ public final class QueryChange {
      * Return the source live query object.
      */
     @NonNull
-    public Query getQuery() {
-        return query;
-    }
+    public Query getQuery() { return query; }
 
     /**
      * Return the new query result.
      */
-    @NonNull
-    public ResultSet getResults() {
-        return rs;
-    }
+    @Nullable
+    public ResultSet getResults() { return rs; }
 
     /**
      * Return the error occurred when running the query.
      */
-    public Throwable getError() {
-        return error;
-    }
+    @Nullable
+    public Throwable getError() { return error; }
 }

--- a/lib/src/shared/test/java/com/couchbase/lite/QueryTest.java
+++ b/lib/src/shared/test/java/com/couchbase/lite/QueryTest.java
@@ -1578,7 +1578,6 @@ public class QueryTest extends BaseQueryTest {
         });
     }
 
-    @Ignore("Fails! CBL-609")
     //https://github.com/couchbase/couchbase-lite-android-ce/issues/34
     @Test
     public void testResultToMapWithBoolean2() throws Exception {

--- a/lib/src/shared/test/java/com/couchbase/lite/ReplicatorOfflineTest.java
+++ b/lib/src/shared/test/java/com/couchbase/lite/ReplicatorOfflineTest.java
@@ -30,7 +30,7 @@ import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 
 
-@Ignore("failing")
+@Ignore("NEW CORE")
 public class ReplicatorOfflineTest extends BaseReplicatorTest {
 
     @Test


### PR DESCRIPTION
This is a big PR.  Sorry.

The main change is that C4Document is no longer RefCounted.
In addition its finalizer no longer attempts to seize a lock (which may already have been GCed)

This change causes changes in other files:
- DocContext no longer manages the C4Document
- AbstractDatabase no longer manages the C4Document

- Document no longer manages the C4Document
  In addition Document no longer needs `free` and `finalizer`
  Also now closer to thread safe

- `shouldRetain` in C4Database is now final
    its finalizer no longer attempts to seize locks.  See above

- QueryChange gets some purely cosmetic changes