### PR TITLE
Fix ProGet URL

### DIFF
--- a/etc/jenkins/build_linux.sh
+++ b/etc/jenkins/build_linux.sh
@@ -5,7 +5,7 @@
 #
 
 LITE_CORE_REPO_URL="http://nexus.build.couchbase.com:8081/nexus/content/repositories/releases/com/couchbase/litecore"
-MAVEN_URL="http://172.23.121.218/maven2/cimaven"
+MAVEN_URL="http://mobile.maven.couchbase.com/maven2/cimaven"
 
 function usage() {
     echo "Usage: $0 <build number> <edition, CE or EE>"

--- a/etc/jenkins/publish.sh
+++ b/etc/jenkins/publish.sh
@@ -5,7 +5,7 @@
 # to the internal maven server.
 #
 
-MAVEN_URL="http://172.23.121.218/maven2/internalmaven"
+MAVEN_URL="http://mobile.maven.couchbase.com/maven2/internalmaven"
 
 function usage() {
     echo "Usage: $0 <build number>"


### PR DESCRIPTION
Fix the ProGet URL, embedded in the build scripts.

Note that this will be merged to the head of release/android/mercury.