### PR TITLE
Hotfix/cbse 8134

### DIFF
--- a/src/main/java/com/couchbase/lite/internal/core/C4QueryEnumerator.java
+++ b/src/main/java/com/couchbase/lite/internal/core/C4QueryEnumerator.java
@@ -109,7 +109,7 @@ public class C4QueryEnumerator {
 
     // NOTE: FLArrayIterator is member variable of C4QueryEnumerator. Not necessary to release.
     public FLArrayIterator getColumns() {
-        return new FLArrayIterator(getColumns(handle));
+        return new FLArrayIterator(getColumns(handle), this);
     }
 
     // -- Accessor methods to C4QueryEnumerator --

--- a/src/main/java/com/couchbase/lite/internal/core/RefCounted.java
+++ b/src/main/java/com/couchbase/lite/internal/core/RefCounted.java
@@ -27,7 +27,7 @@ abstract class RefCounted {
     }
 
     public synchronized void release() {
-        if (--refCount <= 0) { free(); }
+        // if (--refCount <= 0) { free(); }
 
         // For debug
         //if (refCount < 0)

--- a/src/main/java/com/couchbase/lite/internal/fleece/FLArray.java
+++ b/src/main/java/com/couchbase/lite/internal/fleece/FLArray.java
@@ -50,7 +50,7 @@ public class FLArray {
 
     public List<Object> asArray() {
         final List<Object> results = new ArrayList<>();
-        final FLArrayIterator itr = new FLArrayIterator();
+        final FLArrayIterator itr = new FLArrayIterator(this);
         try {
             itr.begin(this);
             FLValue value;

--- a/src/main/java/com/couchbase/lite/internal/fleece/FLArrayIterator.java
+++ b/src/main/java/com/couchbase/lite/internal/fleece/FLArrayIterator.java
@@ -17,6 +17,9 @@
 //
 package com.couchbase.lite.internal.fleece;
 
+import com.couchbase.lite.internal.core.C4QueryEnumerator;
+
+
 public class FLArrayIterator {
     /**
      * Create FLArrayIterator instance
@@ -66,17 +69,22 @@ public class FLArrayIterator {
 
     private final boolean managed;
 
+    // prevent GC of parent, while this object is around
+    @SuppressWarnings("FieldCanBeLocal")
+    private final Object context;
+
+
     //-------------------------------------------------------------------------
     // public methods
     //-------------------------------------------------------------------------
-    public FLArrayIterator() {
-        this.managed = false;
-        this.handle = init();
-    }
+    public FLArrayIterator(FLArray context) { this(init(), context, false); }
 
-    public FLArrayIterator(long handle) {
-        this.managed = true;
+    public FLArrayIterator(long handle, C4QueryEnumerator context) { this(handle, context, true); }
+
+    private FLArrayIterator(long handle, Object context, boolean managed) {
         this.handle = handle;
+        this.context = context;
+        this.managed = true;
     }
 
     //-------------------------------------------------------------------------

--- a/src/main/java/com/couchbase/lite/internal/fleece/FLDict.java
+++ b/src/main/java/com/couchbase/lite/internal/fleece/FLDict.java
@@ -57,7 +57,7 @@ public class FLDict {
 
     public Map<String, Object> asDict() {
         final Map<String, Object> results = new HashMap<>();
-        final FLDictIterator itr = new FLDictIterator();
+        final FLDictIterator itr = new FLDictIterator(this);
         try {
             itr.begin(this);
             String key;

--- a/src/main/java/com/couchbase/lite/internal/fleece/FLDictIterator.java
+++ b/src/main/java/com/couchbase/lite/internal/fleece/FLDictIterator.java
@@ -73,6 +73,10 @@ public class FLDictIterator {
 
     private long handle; // hold pointer to FLDictIterator
 
+    // prevent GC of parent, while this object is around
+    @SuppressWarnings("FieldCanBeLocal")
+    private final Object context;
+
     //-------------------------------------------------------------------------
     // protected methods
     //-------------------------------------------------------------------------
@@ -80,8 +84,13 @@ public class FLDictIterator {
     //-------------------------------------------------------------------------
     // public methods
     //-------------------------------------------------------------------------
-    public FLDictIterator() {
-        handle = init();
+    public FLDictIterator(FLDict context) { this((Object) context); }
+
+    public FLDictIterator(MCollection context) { this((Object) context); }
+
+    private FLDictIterator(Object context) {
+        this.handle = init();
+        this.context = context;
     }
 
     //-------------------------------------------------------------------------

--- a/src/main/java/com/couchbase/lite/internal/fleece/MDict.java
+++ b/src/main/java/com/couchbase/lite/internal/fleece/MDict.java
@@ -80,7 +80,7 @@ public class MDict extends MCollection implements Iterable<String> {
             }
 
             if ((flDict != null) && (flDict.count() > 0)) {
-                final FLDictIterator itr = new FLDictIterator();
+                final FLDictIterator itr = new FLDictIterator(this);
                 try {
                     itr.begin(flDict);
                     String key;
@@ -109,7 +109,7 @@ public class MDict extends MCollection implements Iterable<String> {
         valueMap.clear();
 
         if ((flDict != null) && (flDict.count() > 0)) {
-            final FLDictIterator itr = new FLDictIterator();
+            final FLDictIterator itr = new FLDictIterator(this);
             try {
                 itr.begin(flDict);
                 String key;
@@ -140,7 +140,7 @@ public class MDict extends MCollection implements Iterable<String> {
         }
 
         if ((flDict != null) && (flDict.count() > 0)) {
-            final FLDictIterator itr = new FLDictIterator();
+            final FLDictIterator itr = new FLDictIterator(this);
             try {
                 itr.begin(flDict);
                     String key;


### PR DESCRIPTION
Attempt to make it more difficult to release the document underneath an array/dict iterator.

It turns out that MCollections have a ref to the C4Document into which they point, in their context.  That means the C4Document won't be GCed while the collection is around.  If the iterators keep references to their MCollections, maybe RefCounted is not necessary.