### PR TITLE
Fix LocalRef leak in logger

### DIFF
--- a/lib/src/shared/main/cpp/native_c4.cc
+++ b/lib/src/shared/main/cpp/native_c4.cc
@@ -180,6 +180,12 @@ static void logCallback(C4LogDomain domain, C4LogLevel level, const char *fmt, v
     jstring domainName = env->NewStringUTF(domainNameRaw);
     env->CallStaticVoidMethod(cls_C4Log, m_C4Log_logCallback, domainName, (jint)level, message);
 
+    // Because this method might be called from a thread that is was previously attached
+    // but be called from a long running method, we need to release the local refs.
+    env->DeleteLocalRef(message);
+    if (domainName)
+        env->DeleteLocalRef(domainName);
+
     if(getEnvStat == JNI_EDETACHED) {
         if (gJVM->DetachCurrentThread() != 0) {
             C4Warn("logCallback(): doRequestClose(): Failed to detach the current thread from a Java VM");

--- a/lib/src/shared/main/cpp/native_fleece.cc
+++ b/lib/src/shared/main/cpp/native_fleece.cc
@@ -142,7 +142,7 @@ Java_com_couchbase_lite_internal_fleece_FLDict_get(JNIEnv *env,
                                                    jclass clazz,
                                                    jlong jdict,
                                                    jbyteArray jkeystring) {
-    jbyteArraySlice key(env, jkeystring, true);
+    jbyteArraySlice key(env, jkeystring);
     return (jlong) FLDict_Get((FLDict) jdict, (C4Slice) key);
 }
 


### PR DESCRIPTION
Fix a LocalRef leak in the logger that caused logging during a compaction to fail.